### PR TITLE
Vreg change

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ runtime/libvortexrt.a
 sim/rtlsim/rtlsim
 sim/simx/simx
 sim/vlsim/vortex_afu.h
+third_party/*/**

--- a/sim/simx/Makefile
+++ b/sim/simx/Makefile
@@ -22,11 +22,12 @@ VPATH := $(sort $(dir $(SRCS)))
 #$(info OBJS is $(OBJS))
 #$(info VPATH is $(VPATH))
 
+DEBUG = 1
 # Debugigng
 ifdef DEBUG
 	CXXFLAGS += -g -O0 -DDEBUG_LEVEL=$(DEBUG)
 else    
-	CXXFLAGS += -O2 -DNDEBUG
+	CXXFLAGS += -O2 -DNDEBUG 
 endif
 
 # XLEN parameterization

--- a/sim/simx/archdef.h
+++ b/sim/simx/archdef.h
@@ -7,64 +7,68 @@
 #include <stdio.h>
 #include "types.h"
 
-namespace vortex {
+namespace vortex
+{
 
-class ArchDef {  
-private:
-  uint16_t num_cores_;
-  uint16_t num_warps_;
-  uint16_t num_threads_;
-  uint16_t wsize_;
-  uint16_t vsize_;
-  uint16_t num_regs_;
-  uint16_t num_csrs_;
-  uint16_t num_barriers_;
-  
-public:
-  ArchDef(uint16_t num_cores, 
-          uint16_t num_warps, 
-          uint16_t num_threads)   
-    : num_cores_(num_cores)
-    , num_warps_(num_warps)
-    , num_threads_(num_threads)
-    , wsize_(4)
-    , vsize_(16)
-    , num_regs_(32)
-    , num_csrs_(4096)
-    , num_barriers_(NUM_BARRIERS)
-  {}
+  class ArchDef
+  {
+  private:
+    uint16_t num_cores_;
+    uint16_t num_warps_;
+    uint16_t num_threads_;
+    uint16_t wsize_;
+    uint16_t vsize_; // vk: size of vector register (in bytes)
+    uint16_t num_regs_;
+    uint16_t num_csrs_;
+    uint16_t num_barriers_;
 
-  uint16_t wsize() const { 
-    return wsize_; 
-  }
+  public:
+    ArchDef(uint16_t num_cores,
+            uint16_t num_warps,
+            uint16_t num_threads)
+        : num_cores_(num_cores), num_warps_(num_warps), num_threads_(num_threads), wsize_(4), vsize_(16), num_regs_(32), num_csrs_(4096), num_barriers_(NUM_BARRIERS)
+    {
+    }
 
-  uint16_t vsize() const { 
-    return vsize_; 
-  }
+    uint16_t wsize() const
+    {
+      return wsize_;
+    }
 
-  uint16_t num_regs() const {
-    return num_regs_;
-  }
+    uint16_t vsize() const
+    {
+      return vsize_;
+    }
 
-  uint16_t num_csrs() const {
-    return num_csrs_;
-  }
+    uint16_t num_regs() const
+    {
+      return num_regs_;
+    }
 
-  uint16_t num_barriers() const {
-    return num_barriers_;
-  }
+    uint16_t num_csrs() const
+    {
+      return num_csrs_;
+    }
 
-  uint16_t num_threads() const {
-    return num_threads_;
-  }
+    uint16_t num_barriers() const
+    {
+      return num_barriers_;
+    }
 
-  uint16_t num_warps() const {
-    return num_warps_;
-  }
+    uint16_t num_threads() const
+    {
+      return num_threads_;
+    }
 
-  uint16_t num_cores() const {
-    return num_cores_;
-  }
-};
+    uint16_t num_warps() const
+    {
+      return num_warps_;
+    }
+
+    uint16_t num_cores() const
+    {
+      return num_cores_;
+    }
+  };
 
 }

--- a/sim/simx/decode.cpp
+++ b/sim/simx/decode.cpp
@@ -14,353 +14,527 @@
 
 using namespace vortex;
 
-struct InstTableEntry_t {
+struct InstTableEntry_t
+{
   bool controlFlow;
   InstType iType;
 };
 
 static const std::unordered_map<Opcode, struct InstTableEntry_t> sc_instTable = {
-  {Opcode::NOP,        {false, InstType::N_TYPE}},
-  {Opcode::R_INST,     {false, InstType::R_TYPE}},
-  {Opcode::L_INST,     {false, InstType::I_TYPE}},
-  {Opcode::I_INST,     {false, InstType::I_TYPE}},
-  {Opcode::S_INST,     {false, InstType::S_TYPE}},
-  {Opcode::B_INST,     {true , InstType::B_TYPE}},
-  {Opcode::LUI_INST,   {false, InstType::U_TYPE}},
-  {Opcode::AUIPC_INST, {false, InstType::U_TYPE}},
-  {Opcode::JAL_INST,   {true , InstType::J_TYPE}},
-  {Opcode::JALR_INST,  {true , InstType::I_TYPE}},
-  {Opcode::SYS_INST,   {true , InstType::I_TYPE}},
-  {Opcode::FENCE,      {true , InstType::I_TYPE}},
-  {Opcode::FL,         {false, InstType::I_TYPE}},
-  {Opcode::FS,         {false, InstType::S_TYPE}},
-  {Opcode::FCI,        {false, InstType::R_TYPE}}, 
-  {Opcode::FMADD,      {false, InstType::R4_TYPE}},
-  {Opcode::FMSUB,      {false, InstType::R4_TYPE}},
-  {Opcode::FMNMADD,    {false, InstType::R4_TYPE}},
-  {Opcode::FMNMSUB,    {false, InstType::R4_TYPE}},  
-  {Opcode::VSET,       {false, InstType::V_TYPE}}, 
-  {Opcode::GPGPU,      {false, InstType::R_TYPE}},
-  {Opcode::GPU,        {false, InstType::R4_TYPE}},
-  {Opcode::R_INST_W,   {false, InstType::R_TYPE}},
-  {Opcode::I_INST_W,   {false, InstType::I_TYPE}},
+    {Opcode::NOP, {false, InstType::N_TYPE}},
+    {Opcode::R_INST, {false, InstType::R_TYPE}},
+    {Opcode::L_INST, {false, InstType::I_TYPE}},
+    {Opcode::I_INST, {false, InstType::I_TYPE}},
+    {Opcode::S_INST, {false, InstType::S_TYPE}},
+    {Opcode::B_INST, {true, InstType::B_TYPE}},
+    {Opcode::LUI_INST, {false, InstType::U_TYPE}},
+    {Opcode::AUIPC_INST, {false, InstType::U_TYPE}},
+    {Opcode::JAL_INST, {true, InstType::J_TYPE}},
+    {Opcode::JALR_INST, {true, InstType::I_TYPE}},
+    {Opcode::SYS_INST, {true, InstType::I_TYPE}},
+    {Opcode::FENCE, {true, InstType::I_TYPE}},
+    {Opcode::FL, {false, InstType::I_TYPE}},
+    {Opcode::FS, {false, InstType::S_TYPE}},
+    {Opcode::FCI, {false, InstType::R_TYPE}},
+    {Opcode::FMADD, {false, InstType::R4_TYPE}},
+    {Opcode::FMSUB, {false, InstType::R4_TYPE}},
+    {Opcode::FMNMADD, {false, InstType::R4_TYPE}},
+    {Opcode::FMNMSUB, {false, InstType::R4_TYPE}},
+    {Opcode::VSET, {false, InstType::V_TYPE}},
+    {Opcode::GPGPU, {false, InstType::R_TYPE}},
+    {Opcode::GPU, {false, InstType::R4_TYPE}},
+    {Opcode::R_INST_W, {false, InstType::R_TYPE}},
+    {Opcode::I_INST_W, {false, InstType::I_TYPE}},
 };
 
-enum Constants {
-  width_opcode= 7,
-  width_reg   = 5,
+enum Constants
+{
+  width_opcode = 7,
+  width_reg = 5,
   width_func2 = 2,
   width_func3 = 3,
   width_func6 = 6,
   width_func7 = 7,
-  width_mop   = 3,
+  width_mop = 3,
   width_vmask = 1,
   width_i_imm = 12,
   width_j_imm = 20,
   width_v_imm = 11,
 
-  shift_opcode= 0,
-  shift_rd    = width_opcode,
+  shift_opcode = 0,
+  shift_rd = width_opcode,
   shift_func3 = shift_rd + width_reg,
-  shift_rs1   = shift_func3 + width_func3,
-  shift_rs2   = shift_rs1 + width_reg,
+  shift_rs1 = shift_func3 + width_func3,
+  shift_rs2 = shift_rs1 + width_reg,
   shift_func2 = shift_rs2 + width_reg,
   shift_func7 = shift_rs2 + width_reg,
-  shift_rs3   = shift_func7 + width_func2,
-  shift_vmop  = shift_func7 + width_vmask,
-  shift_vnf   = shift_vmop + width_mop,
+  shift_rs3 = shift_func7 + width_func2,
+  shift_vmop = shift_func7 + width_vmask,
+  shift_vnf = shift_vmop + width_mop,
   shift_func6 = shift_func7 + width_vmask,
-  shift_vset  = shift_func7 + width_func6,
+  shift_vset = shift_func7 + width_func6,
 
-  mask_opcode = (1<<width_opcode)-1,  
-  mask_reg    = (1<<width_reg)-1,
-  mask_func2  = (1<<width_func2)-1,
-  mask_func3  = (1<<width_func3)-1,
-  mask_func6  = (1<<width_func6)-1,
-  mask_func7  = (1<<width_func7)-1,
-  mask_i_imm  = (1<<width_i_imm)-1,
-  mask_j_imm  = (1<<width_j_imm)-1,
-  mask_v_imm  = (1<<width_v_imm)-1,
+  mask_opcode = (1 << width_opcode) - 1,
+  mask_reg = (1 << width_reg) - 1,
+  mask_func2 = (1 << width_func2) - 1,
+  mask_func3 = (1 << width_func3) - 1,
+  mask_func6 = (1 << width_func6) - 1,
+  mask_func7 = (1 << width_func7) - 1,
+  mask_i_imm = (1 << width_i_imm) - 1,
+  mask_j_imm = (1 << width_j_imm) - 1,
+  mask_v_imm = (1 << width_v_imm) - 1,
 };
 
-static const char* op_string(const Instr &instr) {
+static const char *op_string(const Instr &instr)
+{
   auto opcode = instr.getOpcode();
-  auto func2  = instr.getFunc2();
-  auto func3  = instr.getFunc3();
-  auto func7  = instr.getFunc7();
-  auto rs2    = instr.getRSrc(1);
-  auto imm    = instr.getImm();
+  auto func2 = instr.getFunc2();
+  auto func3 = instr.getFunc3();
+  auto func7 = instr.getFunc7();
+  auto rs2 = instr.getRSrc(1);
+  auto imm = instr.getImm();
 
-  switch (opcode) {
-  case Opcode::NOP:        return "NOP";
-  case Opcode::LUI_INST:   return "LUI";
-  case Opcode::AUIPC_INST: return "AUIPC";
+  switch (opcode)
+  {
+  case Opcode::NOP:
+    return "NOP";
+  case Opcode::LUI_INST:
+    return "LUI";
+  case Opcode::AUIPC_INST:
+    return "AUIPC";
   case Opcode::R_INST:
-    if (func7 & 0x1) {
-      switch (func3) {
-      case 0: return "MUL";
-      case 1: return "MULH";
-      case 2: return "MULHSU";
-      case 3: return "MULHU";
-      case 4: return "DIV";
-      case 5: return "DIVU";
-      case 6: return "REM";
-      case 7: return "REMU";
+    if (func7 & 0x1)
+    {
+      switch (func3)
+      {
+      case 0:
+        return "MUL";
+      case 1:
+        return "MULH";
+      case 2:
+        return "MULHSU";
+      case 3:
+        return "MULHU";
+      case 4:
+        return "DIV";
+      case 5:
+        return "DIVU";
+      case 6:
+        return "REM";
+      case 7:
+        return "REMU";
       default:
         std::abort();
       }
-    } else {
-      switch (func3) {
-      case 0: return func7 ? "SUB" : "ADD";
-      case 1: return "SLL";
-      case 2: return "SLT";
-      case 3: return "SLTU";
-      case 4: return "XOR";
-      case 5: return func7 ? "SRA" : "SRL";
-      case 6: return "OR";
-      case 7: return "AND";
+    }
+    else
+    {
+      switch (func3)
+      {
+      case 0:
+        return func7 ? "SUB" : "ADD";
+      case 1:
+        return "SLL";
+      case 2:
+        return "SLT";
+      case 3:
+        return "SLTU";
+      case 4:
+        return "XOR";
+      case 5:
+        return func7 ? "SRA" : "SRL";
+      case 6:
+        return "OR";
+      case 7:
+        return "AND";
       default:
         std::abort();
       }
     }
   case Opcode::I_INST:
-    switch (func3) {
-    case 0: return "ADDI";
-    case 1: return "SLLI";
-    case 2: return "SLTI";
-    case 3: return "SLTIU";
-    case 4: return "XORI";
-    case 5: return func7 ? "SRAI" : "SRLI";
-    case 6: return "ORI";
-    case 7: return "ANDI";
-    default:
-      std::abort();
-    }  
-  case Opcode::B_INST:
-    switch (func3) {
-    case 0: return "BEQ";
-    case 1: return "BNE";
-    case 4: return "BLT";
-    case 5: return "BGE";
-    case 6: return "BLTU";
-    case 7: return "BGEU";
+    switch (func3)
+    {
+    case 0:
+      return "ADDI";
+    case 1:
+      return "SLLI";
+    case 2:
+      return "SLTI";
+    case 3:
+      return "SLTIU";
+    case 4:
+      return "XORI";
+    case 5:
+      return func7 ? "SRAI" : "SRLI";
+    case 6:
+      return "ORI";
+    case 7:
+      return "ANDI";
     default:
       std::abort();
     }
-  case Opcode::JAL_INST:   return "JAL";
-  case Opcode::JALR_INST:  return "JALR";
+  case Opcode::B_INST:
+    switch (func3)
+    {
+    case 0:
+      return "BEQ";
+    case 1:
+      return "BNE";
+    case 4:
+      return "BLT";
+    case 5:
+      return "BGE";
+    case 6:
+      return "BLTU";
+    case 7:
+      return "BGEU";
+    default:
+      std::abort();
+    }
+  case Opcode::JAL_INST:
+    return "JAL";
+  case Opcode::JALR_INST:
+    return "JALR";
   case Opcode::L_INST:
-    switch (func3) {
-    case 0: return "LBI";
-    case 1: return "LHI";
-    case 2: return "LW";
-    case 3: return "LD";
-    case 4: return "LBU";
-    case 5: return "LHU";
-    case 6: return "LWU";
+    switch (func3)
+    {
+    case 0:
+      return "LBI";
+    case 1:
+      return "LHI";
+    case 2:
+      return "LW";
+    case 3:
+      return "LD";
+    case 4:
+      return "LBU";
+    case 5:
+      return "LHU";
+    case 6:
+      return "LWU";
     default:
       std::abort();
     }
   case Opcode::S_INST:
-    switch (func3) {
-    case 0: return "SB";
-    case 1: return "SH";
-    case 2: return "SW";
-    case 3: return "SD";
+    switch (func3)
+    {
+    case 0:
+      return "SB";
+    case 1:
+      return "SH";
+    case 2:
+      return "SW";
+    case 3:
+      return "SD";
     default:
       std::abort();
     }
   case Opcode::R_INST_W:
-    if (func7 & 0x1){
-      switch (func3) {
-      case 0: return "MULW";
-      case 4: return "DIVW";
-      case 5: return "DIVUW";
-      case 6: return "REMW";
-      case 7: return "REMUW";
+    if (func7 & 0x1)
+    {
+      switch (func3)
+      {
+      case 0:
+        return "MULW";
+      case 4:
+        return "DIVW";
+      case 5:
+        return "DIVUW";
+      case 6:
+        return "REMW";
+      case 7:
+        return "REMUW";
       default:
         std::abort();
       }
-    } else {
-      switch (func3) {
-      case 0: return func7 ? "SUBW" : "ADDW";
-      case 1: return "SLLW";
-      case 5: return func7 ? "SRAW" : "SRLW";  
+    }
+    else
+    {
+      switch (func3)
+      {
+      case 0:
+        return func7 ? "SUBW" : "ADDW";
+      case 1:
+        return "SLLW";
+      case 5:
+        return func7 ? "SRAW" : "SRLW";
       default:
         std::abort();
       }
     }
   case Opcode::I_INST_W:
-    switch (func3) {
-      case 0: return "ADDIW";
-      case 1: return "SLLIW";
-      case 5: return func7 ? "SRAIW" : "SRLIW";
-      default:
-        std::abort();
-    }
-  case Opcode::SYS_INST: 
-    switch (func3) {
+    switch (func3)
+    {
     case 0:
-      switch (imm) {
-      case 0x000: return "ECALL";
-      case 0x001: return "EBREAK";
-      case 0x002: return "URET";
-      case 0x102: return "SRET";
-      case 0x302: return "MRET";
-      default:
-        std::abort();      
-      }
-    case 1: return "CSRRW";
-    case 2: return "CSRRS";
-    case 3: return "CSRRC";
-    case 5: return "CSRRWI";
-    case 6: return "CSRRSI";
-    case 7: return "CSRRCI";
+      return "ADDIW";
+    case 1:
+      return "SLLIW";
+    case 5:
+      return func7 ? "SRAIW" : "SRLIW";
     default:
       std::abort();
     }
-  case Opcode::FENCE: return "FENCE";
-  case Opcode::FL: 
-    switch (func3) {
-      case 0x2: return "FLW";
-      case 0x3: return "FLD";
-      case 0x6: return "VL";
-      default: 
+  case Opcode::SYS_INST:
+    switch (func3)
+    {
+    case 0:
+      switch (imm)
+      {
+      case 0x000:
+        return "ECALL";
+      case 0x001:
+        return "EBREAK";
+      case 0x002:
+        return "URET";
+      case 0x102:
+        return "SRET";
+      case 0x302:
+        return "MRET";
+      default:
         std::abort();
+      }
+    case 1:
+      return "CSRRW";
+    case 2:
+      return "CSRRS";
+    case 3:
+      return "CSRRC";
+    case 5:
+      return "CSRRWI";
+    case 6:
+      return "CSRRSI";
+    case 7:
+      return "CSRRCI";
+    default:
+      std::abort();
     }
-  case Opcode::FS: 
-    switch (func3) {
-      case 0x2: return "FSW";
-      case 0x3: return "FSD";
-      case 0x6: return "VS";
-      default: 
-        std::abort();
+  case Opcode::FENCE:
+    return "FENCE";
+  case Opcode::FL:
+    switch (func3)
+    {
+    case 0x2:
+      return "FLW";
+    case 0x3:
+      return "FLD";
+    case 0x6:
+      return "VL";
+    default:
+      std::abort();
     }
-  case Opcode::FCI: 
-    switch (func7) {
-    case 0x00: return "FADD.S";
-    case 0x01: return "FADD.D";
-    case 0x04: return "FSUB.S";
-    case 0x05: return "FSUB.D";
-    case 0x08: return "FMUL.S";
-    case 0x09: return "FMUL.D";
-    case 0x0c: return "FDIV.S";
-    case 0x0d: return "FDIV.D";
-    case 0x2c: return "FSQRT.S";
-    case 0x2d: return "FSQRT.D";
+  case Opcode::FS:
+    switch (func3)
+    {
+    case 0x2:
+      return "FSW";
+    case 0x3:
+      return "FSD";
+    case 0x6:
+      return "VS";
+    default:
+      std::abort();
+    }
+  case Opcode::FCI:
+    switch (func7)
+    {
+    case 0x00:
+      return "FADD.S";
+    case 0x01:
+      return "FADD.D";
+    case 0x04:
+      return "FSUB.S";
+    case 0x05:
+      return "FSUB.D";
+    case 0x08:
+      return "FMUL.S";
+    case 0x09:
+      return "FMUL.D";
+    case 0x0c:
+      return "FDIV.S";
+    case 0x0d:
+      return "FDIV.D";
+    case 0x2c:
+      return "FSQRT.S";
+    case 0x2d:
+      return "FSQRT.D";
     case 0x10:
-      switch (func3) {            
-      case 0: return "FSGNJ.S";
-      case 1: return "FSGNJN.S";
-      case 2: return "FSGNJX.S";
+      switch (func3)
+      {
+      case 0:
+        return "FSGNJ.S";
+      case 1:
+        return "FSGNJN.S";
+      case 2:
+        return "FSGNJX.S";
       default:
         std::abort();
       }
     case 0x11:
-      switch (func3) {            
-      case 0: return "FSGNJ.D";
-      case 1: return "FSGNJN.D";
-      case 2: return "FSGNJX.D";
+      switch (func3)
+      {
+      case 0:
+        return "FSGNJ.D";
+      case 1:
+        return "FSGNJN.D";
+      case 2:
+        return "FSGNJX.D";
       default:
         std::abort();
       }
     case 0x14:
-      switch (func3) {            
-      case 0: return "FMIN.S";
-      case 1: return "FMAX.S";
+      switch (func3)
+      {
+      case 0:
+        return "FMIN.S";
+      case 1:
+        return "FMAX.S";
       default:
         std::abort();
       }
     case 0x15:
-      switch (func3) {            
-      case 0: return "FMIN.D";
-      case 1: return "FMAX.D";
+      switch (func3)
+      {
+      case 0:
+        return "FMIN.D";
+      case 1:
+        return "FMAX.D";
       default:
         std::abort();
       }
-    case 0x20: return "FCVT.S.D";
-    case 0x21: return "FCVT.D.S";
-    case 0x50: 
-      switch (func3) {              
-      case 0: return "FLE.S"; 
-      case 1: return "FLT.S"; 
-      case 2: return "FEQ.S";
+    case 0x20:
+      return "FCVT.S.D";
+    case 0x21:
+      return "FCVT.D.S";
+    case 0x50:
+      switch (func3)
+      {
+      case 0:
+        return "FLE.S";
+      case 1:
+        return "FLT.S";
+      case 2:
+        return "FEQ.S";
       default:
         std::abort();
       }
-    case 0x51: 
-      switch (func3) {              
-      case 0: return "FLE.D"; 
-      case 1: return "FLT.D"; 
-      case 2: return "FEQ.D";
+    case 0x51:
+      switch (func3)
+      {
+      case 0:
+        return "FLE.D";
+      case 1:
+        return "FLT.D";
+      case 2:
+        return "FEQ.D";
       default:
         std::abort();
       }
-    case 0x60: 
-      switch (rs2) {
-      case 0: return "FCVT.W.S";
-      case 1: return "FCVT.WU.S";
-      case 2: return "FCVT.L.S";
-      case 3: return "FCVT.LU.S";
+    case 0x60:
+      switch (rs2)
+      {
+      case 0:
+        return "FCVT.W.S";
+      case 1:
+        return "FCVT.WU.S";
+      case 2:
+        return "FCVT.L.S";
+      case 3:
+        return "FCVT.LU.S";
       default:
         std::abort();
       }
     case 0x61:
-      switch (rs2) {
-      case 0: return "FCVT.W.D";
-      case 1: return "FCVT.WU.D";
-      case 2: return "FCVT.L.D";
-      case 3: return "FCVT.LU.D";
+      switch (rs2)
+      {
+      case 0:
+        return "FCVT.W.D";
+      case 1:
+        return "FCVT.WU.D";
+      case 2:
+        return "FCVT.L.D";
+      case 3:
+        return "FCVT.LU.D";
       default:
         std::abort();
       }
-    case 0x68: 
-      switch (rs2) {
-      case 0: return "FCVT.S.W";
-      case 1: return "FCVT.S.WU";
-      case 2: return "FCVT.S.L";
-      case 3: return "FCVT.S.LU";
+    case 0x68:
+      switch (rs2)
+      {
+      case 0:
+        return "FCVT.S.W";
+      case 1:
+        return "FCVT.S.WU";
+      case 2:
+        return "FCVT.S.L";
+      case 3:
+        return "FCVT.S.LU";
       default:
         std::abort();
       }
     case 0x69:
-      switch (rs2) {
-      case 0: return "FCVT.D.W";
-      case 1: return "FCVT.D.WU";
-      case 2: return "FCVT.D.L";
-      case 3: return "FCVT.D.LU";
+      switch (rs2)
+      {
+      case 0:
+        return "FCVT.D.W";
+      case 1:
+        return "FCVT.D.WU";
+      case 2:
+        return "FCVT.D.L";
+      case 3:
+        return "FCVT.D.LU";
       default:
         std::abort();
       }
-    case 0x70: return func3 ? "FCLASS.S" : "FMV.X.W";
-    case 0x71: return func3 ? "FCLASS.D" : "FMV.X.D";
-    case 0x78: return "FMV.W.X";
-    case 0x79: return "FMV.D.X";
+    case 0x70:
+      return func3 ? "FCLASS.S" : "FMV.X.W";
+    case 0x71:
+      return func3 ? "FCLASS.D" : "FMV.X.D";
+    case 0x78:
+      return "FMV.W.X";
+    case 0x79:
+      return "FMV.D.X";
     default:
       std::abort();
     }
-  case Opcode::FMADD:   return func2 ? "FMADD.D" : "FMADD.S";
-  case Opcode::FMSUB:   return func2 ? "FMSUB.D" : "FMSUB.S";
-  case Opcode::FMNMADD: return func2 ? "FNMADD.D" : "FNMADD.S";
-  case Opcode::FMNMSUB: return func2 ? "FNMSUB.D" : "FNMSUB.S";
-  case Opcode::VSET:    return "VSET";
+  case Opcode::FMADD:
+    return func2 ? "FMADD.D" : "FMADD.S";
+  case Opcode::FMSUB:
+    return func2 ? "FMSUB.D" : "FMSUB.S";
+  case Opcode::FMNMADD:
+    return func2 ? "FNMADD.D" : "FNMADD.S";
+  case Opcode::FMNMSUB:
+    return func2 ? "FNMSUB.D" : "FNMSUB.S";
+  case Opcode::VSET:
+    return "VSET";
   case Opcode::GPGPU:
-    switch (func3) {            
-    case 0: return "TMC";
-    case 1: return "WSPAWN";
-    case 2: return "SPLIT";
-    case 3: return "JOIN";
-    case 4: return "BAR";
-    case 5: return "PREFETCH";
+    switch (func3)
+    {
+    case 0:
+      return "TMC";
+    case 1:
+      return "WSPAWN";
+    case 2:
+      return "SPLIT";
+    case 3:
+      return "JOIN";
+    case 4:
+      return "BAR";
+    case 5:
+      return "PREFETCH";
     default:
       std::abort();
     }
   case Opcode::GPU:
-    switch (func3) {
-    case 0: return "TEX";
-    case 1: {
-      switch (func2) {
-      case 0: return "CMOV";
+    switch (func3)
+    {
+    case 0:
+      return "TEX";
+    case 1:
+    {
+      switch (func2)
+      {
+      case 0:
+        return "CMOV";
       default:
         std::abort();
       }
@@ -373,47 +547,58 @@ static const char* op_string(const Instr &instr) {
   }
 }
 
-namespace vortex {
-std::ostream &operator<<(std::ostream &os, const Instr &instr) {  
-  auto opcode = instr.getOpcode();    
-  auto func2  = instr.getFunc2();
-  auto func3  = instr.getFunc3();
+namespace vortex
+{
+  std::ostream &operator<<(std::ostream &os, const Instr &instr)
+  {
+    auto opcode = instr.getOpcode();
+    auto func2 = instr.getFunc2();
+    auto func3 = instr.getFunc3();
 
-  os << op_string(instr) << ": ";
+    os << op_string(instr) << ": ";
 
-  if (opcode == S_INST 
-   || opcode == FS) {     
-     os << "M[r" << std::dec << instr.getRSrc(0) << " + 0x" << std::hex << instr.getImm() << "] <- ";
-     os << instr.getRSType(1) << std::dec << instr.getRSrc(1);
-  } else 
-  if (opcode == L_INST 
-   || opcode == FL) {     
-     os << instr.getRDType() << std::dec << instr.getRDest() << " <- ";
-     os << "M[r" << std::dec << instr.getRSrc(0) << " + 0x" << std::hex << instr.getImm() << "]";
-  } else {
-    if (instr.getRDType() != RegType::None) {
+    if (opcode == S_INST || opcode == FS)
+    {
+      os << "M[r" << std::dec << instr.getRSrc(0) << " + 0x" << std::hex << instr.getImm() << "] <- ";
+      os << instr.getRSType(1) << std::dec << instr.getRSrc(1);
+    }
+    else if (opcode == L_INST || opcode == FL)
+    {
       os << instr.getRDType() << std::dec << instr.getRDest() << " <- ";
+      os << "M[r" << std::dec << instr.getRSrc(0) << " + 0x" << std::hex << instr.getImm() << "]";
     }
-    uint32_t i = 0;
-    for (; i < instr.getNRSrc(); ++i) {    
-      if (i) os << ", ";
-      os << instr.getRSType(i) << std::dec << instr.getRSrc(i);
-    }    
-    if (instr.hasImm()) {
-      if (i) os << ", ";
-      os << "imm=0x" << std::hex << instr.getImm();
+    else
+    {
+      if (instr.getRDType() != RegType::None)
+      {
+        os << instr.getRDType() << std::dec << instr.getRDest() << " <- ";
+      }
+      uint32_t i = 0;
+      for (; i < instr.getNRSrc(); ++i)
+      {
+        if (i)
+          os << ", ";
+        os << instr.getRSType(i) << std::dec << instr.getRSrc(i);
+      }
+      if (instr.hasImm())
+      {
+        if (i)
+          os << ", ";
+        os << "imm=0x" << std::hex << instr.getImm();
+      }
+      if (opcode == GPU && func3 == 0)
+      {
+        os << ", unit=" << std::dec << func2;
+      }
     }
-    if (opcode == GPU && func3 == 0) {
-      os << ", unit=" << std::dec << func2;
-    }
+    return os;
   }
-  return os;
-}
 }
 
-Decoder::Decoder(const ArchDef&) {}
+Decoder::Decoder(const ArchDef &) {}
 
-std::shared_ptr<Instr> Decoder::decode(uint32_t code) const {  
+std::shared_ptr<Instr> Decoder::decode(uint32_t code) const
+{
   auto instr = std::make_shared<Instr>();
   auto op = Opcode((code >> shift_opcode) & mask_opcode);
   instr->setOpcode(op);
@@ -423,31 +608,37 @@ std::shared_ptr<Instr> Decoder::decode(uint32_t code) const {
   auto func6 = (code >> shift_func6) & mask_func6;
   auto func7 = (code >> shift_func7) & mask_func7;
 
-  auto rd  = (code >> shift_rd)  & mask_reg;
+  auto rd = (code >> shift_rd) & mask_reg;
   auto rs1 = (code >> shift_rs1) & mask_reg;
   auto rs2 = (code >> shift_rs2) & mask_reg;
   auto rs3 = (code >> shift_rs3) & mask_reg;
 
   auto op_it = sc_instTable.find(op);
-  if (op_it == sc_instTable.end()) {
+  if (op_it == sc_instTable.end())
+  {
     std::cout << std::hex << "Error: invalid opcode: 0x" << op << std::endl;
     return nullptr;
   }
 
   auto iType = op_it->second.iType;
-  if (op == Opcode::FL || op == Opcode::FS) { 
-    if (func3 != 0x2 && func3 != 0x3) {
+  if (op == Opcode::FL || op == Opcode::FS)
+  {
+    if (func3 != 0x2 && func3 != 0x3)
+    {
       iType = InstType::V_TYPE;
     }
   }
 
-  switch (iType) {
+  switch (iType)
+  {
   case InstType::N_TYPE:
     break;
 
   case InstType::R_TYPE:
-    if (op == Opcode::FCI) {
-      switch (func7) {      
+    if (op == Opcode::FCI)
+    {
+      switch (func7)
+      {
       case 0x50: // FLE.S, FLT.S, FEQ.S
       case 0x51: // FLE.D, FLT.D, FEQ.D
         instr->setDestReg(rd, RegType::Integer);
@@ -467,22 +658,24 @@ std::shared_ptr<Instr> Decoder::decode(uint32_t code) const {
         instr->setSrcReg(rs2, RegType::Integer);
         break;
       case 0x70: // FCLASS.S, FMV.X.W
-      case 0x71: // FCLASS.D, FMV.X.D        
+      case 0x71: // FCLASS.D, FMV.X.D
         instr->setDestReg(rd, RegType::Integer);
         instr->setSrcReg(rs1, RegType::Float);
         break;
       case 0x78: // FMV.W.X
-      case 0x79: // FMV.D.X        
+      case 0x79: // FMV.D.X
         instr->setDestReg(rd, RegType::Float);
         instr->setSrcReg(rs1, RegType::Integer);
         break;
       default:
         instr->setDestReg(rd, RegType::Float);
         instr->setSrcReg(rs1, RegType::Float);
-        instr->setSrcReg(rs2, RegType::Float);        
+        instr->setSrcReg(rs2, RegType::Float);
         break;
       }
-    } else {
+    }
+    else
+    {
       instr->setDestReg(rd, RegType::Integer);
       instr->setSrcReg(rs1, RegType::Integer);
       instr->setSrcReg(rs2, RegType::Integer);
@@ -491,18 +684,24 @@ std::shared_ptr<Instr> Decoder::decode(uint32_t code) const {
     instr->setFunc7(func7);
     break;
 
-  case InstType::I_TYPE: {
+  case InstType::I_TYPE:
+  {
     instr->setSrcReg(rs1, RegType::Integer);
-    if (op == Opcode::FL) {
-      instr->setDestReg(rd, RegType::Float);      
-    } else {
+    if (op == Opcode::FL)
+    {
+      instr->setDestReg(rd, RegType::Float);
+    }
+    else
+    {
       instr->setDestReg(rd, RegType::Integer);
-    }    
+    }
     instr->setFunc3(func3);
     instr->setFunc7(func7);
-    switch (op) {
+    switch (op)
+    {
     case Opcode::SYS_INST:
-      if (func3 != 0) {
+      if (func3 != 0)
+      {
         // RV32I: CSR*
         instr->setDestReg(rd, RegType::Integer);
       }
@@ -515,16 +714,20 @@ std::shared_ptr<Instr> Decoder::decode(uint32_t code) const {
       break;
     case Opcode::I_INST:
     case Opcode::I_INST_W:
-      if (func3 == 0x1 || func3 == 0x5) {
+      if (func3 == 0x1 || func3 == 0x5)
+      {
         auto shamt = rs2; // uint5
-      #if (XLEN == 64)
-        if (op == Opcode::I_INST) {
+#if (XLEN == 64)
+        if (op == Opcode::I_INST)
+        {
           // uint6
           shamt |= ((func7 & 0x1) << 5);
         }
-      #endif
+#endif
         instr->setImm(shamt);
-      } else {
+      }
+      else
+      {
         // int12
         auto imm = code >> shift_rs2;
         instr->setImm(sext(imm, width_i_imm));
@@ -536,88 +739,109 @@ std::shared_ptr<Instr> Decoder::decode(uint32_t code) const {
       instr->setImm(sext(imm, width_i_imm));
       break;
     }
-  } break;
-  case InstType::S_TYPE: {    
+  }
+  break;
+  case InstType::S_TYPE:
+  {
     instr->setSrcReg(rs1, RegType::Integer);
-    if (op == Opcode::FS) {
+    if (op == Opcode::FS)
+    {
       instr->setSrcReg(rs2, RegType::Float);
-    } else {
+    }
+    else
+    {
       instr->setSrcReg(rs2, RegType::Integer);
     }
     instr->setFunc3(func3);
     auto imm = (func7 << width_reg) | rd;
     instr->setImm(sext(imm, width_i_imm));
-  } break;
+  }
+  break;
 
-  case InstType::B_TYPE: {
+  case InstType::B_TYPE:
+  {
     instr->setSrcReg(rs1, RegType::Integer);
     instr->setSrcReg(rs2, RegType::Integer);
     instr->setFunc3(func3);
-    auto bit_11   = rd & 0x1;
+    auto bit_11 = rd & 0x1;
     auto bits_4_1 = rd >> 1;
     auto bit_10_5 = func7 & 0x3f;
-    auto bit_12   = func7 >> 6;
+    auto bit_12 = func7 >> 6;
     auto imm = (bits_4_1 << 1) | (bit_10_5 << 5) | (bit_11 << 11) | (bit_12 << 12);
-    instr->setImm(sext(imm, width_i_imm+1));
-  } break;
+    instr->setImm(sext(imm, width_i_imm + 1));
+  }
+  break;
 
-  case InstType::U_TYPE: {
+  case InstType::U_TYPE:
+  {
     instr->setDestReg(rd, RegType::Integer);
     auto imm = code >> shift_func3;
     instr->setImm(sext(imm, width_j_imm));
-  }  break;
+  }
+  break;
 
-  case InstType::J_TYPE: {
+  case InstType::J_TYPE:
+  {
     instr->setDestReg(rd, RegType::Integer);
-    auto unordered  = code >> shift_func3;
+    auto unordered = code >> shift_func3;
     auto bits_19_12 = unordered & 0xff;
-    auto bit_11     = (unordered >> 8) & 0x1;
-    auto bits_10_1  = (unordered >> 9) & 0x3ff;
-    auto bit_20     = (unordered >> 19) & 0x1;
+    auto bit_11 = (unordered >> 8) & 0x1;
+    auto bits_10_1 = (unordered >> 9) & 0x3ff;
+    auto bit_20 = (unordered >> 19) & 0x1;
     auto imm = (bits_10_1 << 1) | (bit_11 << 11) | (bits_19_12 << 12) | (bit_20 << 20);
-    instr->setImm(sext(imm, width_j_imm+1));
-  } break;
-    
+    instr->setImm(sext(imm, width_j_imm + 1));
+  }
+  break;
+
   case InstType::V_TYPE:
-    switch (op) {
-    case Opcode::VSET: {
+    switch (op)
+    {
+    case Opcode::VSET:
+    {
       instr->setDestVReg(rd);
       instr->setSrcVReg(rs1);
       instr->setFunc3(func3);
-      if (func3 == 7) { 
+      if (func3 == 7)
+      {
         instr->setImm(!(code >> shift_vset));
-        if (instr->getImm()) { //arv: vsetvli
+        if (instr->getImm())
+        { // arv: vsetvli
           auto immed = (code >> shift_rs2) & mask_v_imm;
           instr->setImm(immed);
           instr->setVlmul(immed & 0x7);
-          //arv: instr->setVediv((immed >> 4) & 0x3);
+          // arv: instr->setVediv((immed >> 4) & 0x3);
           instr->setVsew((immed >> 3) & 0x7);
-        } else { //arv: vsetvl(check)
+        }
+        else
+        { // arv: vsetvl(check)
           instr->setSrcVReg(rs2);
         }
-      } else { //arv: vector arithmetic
+      }
+      else
+      { // arv: vector arithmetic
         instr->setSrcVReg(rs2);
-        instr->setVmask((code >> shift_func7) & 0x1);
+        instr->setVmask((code >> shift_func7) & 0x1); // vk: 25th bit is vmask
         instr->setFunc6(func6);
       }
-    } break;
+    }
+    break;
 
-    case Opcode::FL: //arv: vector load
+    case Opcode::FL: // arv: vector load
       instr->setDestVReg(rd);
       instr->setSrcVReg(rs1);
       instr->setFunc3(func3);
-      instr->setVlsWidth(func3); //arv: check
+      instr->setVlsWidth(func3); // arv: check
       instr->setSrcVReg(rs2);
       instr->setVmask((code >> shift_func7) & 0x1);
       instr->setVmop((code >> shift_vmop) & 0x3);
       instr->setVnf((code >> shift_vnf) & mask_func3);
       break;
 
-    case Opcode::FS: //arv: vector store
+    case Opcode::FS: // arv: vector store
       instr->setVs3(rd);
       instr->setSrcVReg(rs1);
       instr->setFunc3(func3);
-      instr->setVlsWidth(func3); //arv: check
+      instr->setVlsWidth(func3); // arv: check
       instr->setSrcVReg(rs2);
       instr->setVmask((code >> shift_func7) & 0x1);
       instr->setVmop((code >> shift_vmop) & 0x3);
@@ -629,12 +853,15 @@ std::shared_ptr<Instr> Decoder::decode(uint32_t code) const {
     }
     break;
   case R4_TYPE:
-    if (op == Opcode::GPU) {
+    if (op == Opcode::GPU)
+    {
       instr->setDestReg(rd, RegType::Integer);
       instr->setSrcReg(rs1, RegType::Integer);
       instr->setSrcReg(rs2, RegType::Integer);
       instr->setSrcReg(rs3, RegType::Integer);
-    } else {
+    }
+    else
+    {
       instr->setDestReg(rd, RegType::Float);
       instr->setSrcReg(rs1, RegType::Float);
       instr->setSrcReg(rs2, RegType::Float);

--- a/sim/simx/execute.cpp
+++ b/sim/simx/execute.cpp
@@ -15,28 +15,35 @@
 
 using namespace vortex;
 
-union reg_data_t {
-  Word     i;  
-  FWord    f;
+union reg_data_t
+{
+  Word i;
+  FWord f;
   uint64_t _;
 };
 
-static bool HasDivergentThreads(const ThreadMask &thread_mask,                                
+static bool HasDivergentThreads(const ThreadMask &thread_mask,
                                 const std::vector<std::vector<Word>> &reg_file,
-                                unsigned reg) {
+                                unsigned reg)
+{
   bool cond;
   size_t thread_idx = 0;
   size_t num_threads = reg_file.size();
-  for (; thread_idx < num_threads; ++thread_idx) {
-    if (thread_mask[thread_idx]) {
+  for (; thread_idx < num_threads; ++thread_idx)
+  {
+    if (thread_mask[thread_idx])
+    {
       cond = bool(reg_file[thread_idx][reg]);
       break;
     }
-  }  
-  assert(thread_idx != num_threads);  
-  for (; thread_idx < num_threads; ++thread_idx) {
-    if (thread_mask[thread_idx]) {
-      if (cond != (bool(reg_file[thread_idx][reg]))) {
+  }
+  assert(thread_idx != num_threads);
+  for (; thread_idx < num_threads; ++thread_idx)
+  {
+    if (thread_mask[thread_idx])
+    {
+      if (cond != (bool(reg_file[thread_idx][reg])))
+      {
         return true;
       }
     }
@@ -44,38 +51,49 @@ static bool HasDivergentThreads(const ThreadMask &thread_mask,
   return false;
 }
 
-inline uint32_t get_fpu_rm(uint32_t func3, Core* core, uint32_t tid, uint32_t wid) {
+inline uint32_t get_fpu_rm(uint32_t func3, Core *core, uint32_t tid, uint32_t wid)
+{
   return (func3 == 0x7) ? core->get_csr(CSR_FRM, tid, wid) : func3;
 }
 
-static void update_fcrs(uint32_t fflags, Core* core, uint32_t tid, uint32_t wid) {
-  if (fflags) {
+static void update_fcrs(uint32_t fflags, Core *core, uint32_t tid, uint32_t wid)
+{
+  if (fflags)
+  {
     core->set_csr(CSR_FCSR, core->get_csr(CSR_FCSR, tid, wid) | fflags, tid, wid);
     core->set_csr(CSR_FFLAGS, core->get_csr(CSR_FFLAGS, tid, wid) | fflags, tid, wid);
   }
 }
 
-inline uint64_t nan_box(uint32_t value) {
+inline uint64_t nan_box(uint32_t value)
+{
   uint64_t mask = 0xffffffff00000000;
   return value | mask;
 }
 
-inline bool is_nan_boxed(uint64_t value) {
+inline bool is_nan_boxed(uint64_t value)
+{
   return (uint32_t(value >> 32) == 0xffffffff);
 }
 
-static bool checkBoxedArgs(FWord* out, FWord a, FWord b, uint32_t* fflags) {  
+static bool checkBoxedArgs(FWord *out, FWord a, FWord b, uint32_t *fflags)
+{
   bool xa = is_nan_boxed(a);
-  bool xb = is_nan_boxed(b);  
+  bool xb = is_nan_boxed(b);
   if (xa && xb)
     return true;
-  if (xa) {
+  if (xa)
+  {
     // a is NaN boxed but b isn't
     *out = nan_box((uint32_t)a);
-  } else if (xb) {
+  }
+  else if (xb)
+  {
     // b is NaN boxed but a isn't
     *out = nan_box(0xffc00000);
-  } else {
+  }
+  else
+  {
     // Both a and b aren't NaN boxed
     *out = nan_box(0x7fc00000);
   }
@@ -83,7 +101,8 @@ static bool checkBoxedArgs(FWord* out, FWord a, FWord b, uint32_t* fflags) {
   return false;
 }
 
-static bool checkBoxedArgs(FWord* out, FWord a, uint32_t* fflags) {  
+static bool checkBoxedArgs(FWord *out, FWord a, uint32_t *fflags)
+{
   bool xa = is_nan_boxed(a);
   if (xa)
     return true;
@@ -92,9 +111,10 @@ static bool checkBoxedArgs(FWord* out, FWord a, uint32_t* fflags) {
   return false;
 }
 
-static bool checkBoxedCmpArgs(Word* out, FWord a, FWord b, uint32_t* fflags) {  
+static bool checkBoxedCmpArgs(Word *out, FWord a, FWord b, uint32_t *fflags)
+{
   bool xa = is_nan_boxed(a);
-  bool xb = is_nan_boxed(b);  
+  bool xb = is_nan_boxed(b);
   if (xa && xb)
     return true;
   *out = 0;
@@ -102,23 +122,24 @@ static bool checkBoxedCmpArgs(Word* out, FWord a, FWord b, uint32_t* fflags) {
   return false;
 }
 
-void Warp::execute(const Instr &instr, pipeline_trace_t *trace) {
+void Warp::execute(const Instr &instr, pipeline_trace_t *trace)
+{
   assert(tmask_.any());
 
   auto nextPC = PC_ + core_->arch().wsize();
 
-  auto func2  = instr.getFunc2();
-  auto func3  = instr.getFunc3();
-  auto func6  = instr.getFunc6();
-  auto func7  = instr.getFunc7();
+  auto func2 = instr.getFunc2();
+  auto func3 = instr.getFunc3();
+  auto func6 = instr.getFunc6();
+  auto func7 = instr.getFunc7();
 
   auto opcode = instr.getOpcode();
-  auto rdest  = instr.getRDest();
-  auto rsrc0  = instr.getRSrc(0);
-  auto rsrc1  = instr.getRSrc(1);
-  auto rsrc2  = instr.getRSrc(2);
+  auto rdest = instr.getRDest();
+  auto rsrc0 = instr.getRSrc(0);
+  auto rsrc1 = instr.getRSrc(1);
+  auto rsrc2 = instr.getRSrc(2);
   auto immsrc = sext((Word)instr.getImm(), 32);
-  auto vmask  = instr.getVmask();
+  auto vmask = instr.getVmask();
 
   auto num_threads = core_->arch().num_threads();
 
@@ -126,96 +147,116 @@ void Warp::execute(const Instr &instr, pipeline_trace_t *trace) {
   std::vector<reg_data_t> rddata(num_threads);
 
   auto num_rsrcs = instr.getNRSrc();
-  if (num_rsrcs) {              
-    for (uint32_t i = 0; i < num_rsrcs; ++i) {    
+  if (num_rsrcs)
+  {
+    for (uint32_t i = 0; i < num_rsrcs; ++i)
+    {
       DPH(2, "Src Reg [" << std::dec << i << "]: ");
       auto type = instr.getRSType(i);
-      auto reg = instr.getRSrc(i);        
-      switch (type) {
-      case RegType::Integer: 
+      auto reg = instr.getRSrc(i);
+      switch (type)
+      {
+      case RegType::Integer:
         DPN(2, type << std::dec << reg << "={");
-        for (uint32_t t = 0; t < num_threads; ++t) {
-          if (t) DPN(2, ", ");
-          if (!tmask_.test(t)) {
+        for (uint32_t t = 0; t < num_threads; ++t)
+        {
+          if (t)
+            DPN(2, ", ");
+          if (!tmask_.test(t))
+          {
             DPN(2, "-");
-            continue;            
+            continue;
           }
-          rsdata[t][i].i = ireg_file_.at(t)[reg];          
-          DPN(2, std::hex << rsdata[t][i].i); 
+          rsdata[t][i].i = ireg_file_.at(t)[reg];
+          DPN(2, std::hex << rsdata[t][i].i);
         }
         DPN(2, "}" << std::endl);
         break;
-      case RegType::Float: 
+      case RegType::Float:
         DPN(2, type << std::dec << reg << "={");
-        for (uint32_t t = 0; t < num_threads; ++t) {
-          if (t) DPN(2, ", ");
-          if (!tmask_.test(t)) {
+        for (uint32_t t = 0; t < num_threads; ++t)
+        {
+          if (t)
+            DPN(2, ", ");
+          if (!tmask_.test(t))
+          {
             DPN(2, "-");
-            continue;            
+            continue;
           }
           rsdata[t][i].f = freg_file_.at(t)[reg];
-          DPN(2, std::hex << rsdata[t][i].f); 
+          DPN(2, std::hex << rsdata[t][i].f);
         }
         DPN(2, "}" << std::endl);
         break;
-      case RegType::Vector: //arv: data decoded later 
+      case RegType::Vector: // arv: data decoded later
         if (((opcode == VSET) && (func3 == 0x7)) || (((opcode == FL) || (opcode == FS)) && (func3 == 0x6)))
-          rsdata[0][i].i = ireg_file_.at(0)[reg];
+          rsdata[0][i].i = ireg_file_.at(0)[reg]; // vk: simd, only 1 thread, stores int src args used in vreg cfg instrs like vsetvli
         DPN(2, type);
         break;
-      default: 
+      default:
         std::abort();
         break;
-      }      
+      }
     }
   }
 
   bool rd_write = false;
-  
-  switch (opcode) {
+
+  switch (opcode)
+  {
   case NOP:
     break;
   // RV32I: LUI
-  case LUI_INST: {
+  case LUI_INST:
+  {
     trace->exe_type = ExeType::ALU;
     trace->alu.type = AluType::ARITH;
-    for (uint32_t t = 0; t < num_threads; ++t) {
+    for (uint32_t t = 0; t < num_threads; ++t)
+    {
       if (!tmask_.test(t))
         continue;
       rddata[t].i = immsrc << 12;
-    }    
+    }
     rd_write = true;
     break;
   }
   // RV32I: AUIPC
-  case AUIPC_INST: {
+  case AUIPC_INST:
+  {
     trace->exe_type = ExeType::ALU;
     trace->alu.type = AluType::ARITH;
-    for (uint32_t t = 0; t < num_threads; ++t) {
+    for (uint32_t t = 0; t < num_threads; ++t)
+    {
       if (!tmask_.test(t))
         continue;
       rddata[t].i = (immsrc << 12) + PC_;
-    }    
+    }
     rd_write = true;
     break;
   }
-  case R_INST: {
-    trace->exe_type = ExeType::ALU;    
+  case R_INST:
+  {
+    trace->exe_type = ExeType::ALU;
     trace->alu.type = AluType::ARITH;
     trace->used_iregs.set(rsrc0);
     trace->used_iregs.set(rsrc1);
-    for (uint32_t t = 0; t < num_threads; ++t) {
+    for (uint32_t t = 0; t < num_threads; ++t)
+    {
       if (!tmask_.test(t))
         continue;
-      if (func7 & 0x1) {
-        switch (func3) {
-        case 0: {
+      if (func7 & 0x1)
+      {
+        switch (func3)
+        {
+        case 0:
+        {
           // RV32M: MUL
           rddata[t].i = (WordI)rsdata[t][0].i * (WordI)rsdata[t][1].i;
           trace->alu.type = AluType::IMUL;
           break;
         }
-        case 1: {
+        case 1:
+        {
           // RV32M: MULH
           DWordI first = sext((DWord)rsdata[t][0].i, XLEN);
           DWordI second = sext((DWord)rsdata[t][1].i, XLEN);
@@ -223,131 +264,170 @@ void Warp::execute(const Instr &instr, pipeline_trace_t *trace) {
           trace->alu.type = AluType::IMUL;
           break;
         }
-        case 2: {
-          // RV32M: MULHSU       
+        case 2:
+        {
+          // RV32M: MULHSU
           DWordI first = sext((DWord)rsdata[t][0].i, XLEN);
           DWord second = rsdata[t][1].i;
           rddata[t].i = (first * second) >> XLEN;
           trace->alu.type = AluType::IMUL;
           break;
-        } 
-        case 3: {
+        }
+        case 3:
+        {
           // RV32M: MULHU
           DWord first = rsdata[t][0].i;
           DWord second = rsdata[t][1].i;
           rddata[t].i = (first * second) >> XLEN;
           trace->alu.type = AluType::IMUL;
           break;
-        } 
-        case 4: {
+        }
+        case 4:
+        {
           // RV32M: DIV
           WordI dividen = rsdata[t][0].i;
-          WordI divisor = rsdata[t][1].i; 
-          WordI largest_negative = WordI(1) << (XLEN-1);  
-          if (divisor == 0) {
+          WordI divisor = rsdata[t][1].i;
+          WordI largest_negative = WordI(1) << (XLEN - 1);
+          if (divisor == 0)
+          {
             rddata[t].i = -1;
-          } else if (dividen == largest_negative && divisor == -1) {
+          }
+          else if (dividen == largest_negative && divisor == -1)
+          {
             rddata[t].i = dividen;
-          } else {
+          }
+          else
+          {
             rddata[t].i = dividen / divisor;
           }
           trace->alu.type = AluType::IDIV;
           break;
-        } 
-        case 5: {
+        }
+        case 5:
+        {
           // RV32M: DIVU
           Word dividen = rsdata[t][0].i;
           Word divisor = rsdata[t][1].i;
-          if (divisor == 0) {
+          if (divisor == 0)
+          {
             rddata[t].i = -1;
-          } else {
+          }
+          else
+          {
             rddata[t].i = dividen / divisor;
           }
           trace->alu.type = AluType::IDIV;
           break;
-        } 
-        case 6: {
+        }
+        case 6:
+        {
           // RV32M: REM
           WordI dividen = rsdata[t][0].i;
           WordI divisor = rsdata[t][1].i;
-          WordI largest_negative = WordI(1) << (XLEN-1);
-          if (rsdata[t][1].i == 0) {
+          WordI largest_negative = WordI(1) << (XLEN - 1);
+          if (rsdata[t][1].i == 0)
+          {
             rddata[t].i = dividen;
-          } else if (dividen == largest_negative && divisor == -1) {
+          }
+          else if (dividen == largest_negative && divisor == -1)
+          {
             rddata[t].i = 0;
-          } else {
+          }
+          else
+          {
             rddata[t].i = dividen % divisor;
           }
           trace->alu.type = AluType::IDIV;
           break;
-        } 
-        case 7: {
+        }
+        case 7:
+        {
           // RV32M: REMU
           Word dividen = rsdata[t][0].i;
           Word divisor = rsdata[t][1].i;
-          if (rsdata[t][1].i == 0) {
+          if (rsdata[t][1].i == 0)
+          {
             rddata[t].i = dividen;
-          } else {
+          }
+          else
+          {
             rddata[t].i = dividen % divisor;
           }
           trace->alu.type = AluType::IDIV;
           break;
-        } 
+        }
         default:
           std::abort();
         }
-      } else {
-        switch (func3) {
-        case 0: {
-          if (func7) {
+      }
+      else
+      {
+        switch (func3)
+        {
+        case 0:
+        {
+          if (func7)
+          {
             // RV32I: SUB
             rddata[t].i = rsdata[t][0].i - rsdata[t][1].i;
-          } else {
+          }
+          else
+          {
             // RV32I: ADD
             rddata[t].i = rsdata[t][0].i + rsdata[t][1].i;
           }
           break;
         }
-        case 1: {
+        case 1:
+        {
           // RV32I: SLL
           Word shamt_mask = (Word(1) << log2up(XLEN)) - 1;
           Word shamt = rsdata[t][1].i & shamt_mask;
           rddata[t].i = rsdata[t][0].i << shamt;
           break;
         }
-        case 2: {
+        case 2:
+        {
           // RV32I: SLT
           rddata[t].i = WordI(rsdata[t][0].i) < WordI(rsdata[t][1].i);
           break;
         }
-        case 3: {
+        case 3:
+        {
           // RV32I: SLTU
           rddata[t].i = Word(rsdata[t][0].i) < Word(rsdata[t][1].i);
           break;
         }
-        case 4: {
+        case 4:
+        {
           // RV32I: XOR
           rddata[t].i = rsdata[t][0].i ^ rsdata[t][1].i;
           break;
         }
-        case 5: {
+        case 5:
+        {
           Word shamt_mask = ((Word)1 << log2up(XLEN)) - 1;
           Word shamt = rsdata[t][1].i & shamt_mask;
-          if (func7) {
+          if (func7)
+          {
             // RV32I: SRA
             rddata[t].i = WordI(rsdata[t][0].i) >> shamt;
-          } else {
+          }
+          else
+          {
             // RV32I: SRL
             rddata[t].i = Word(rsdata[t][0].i) >> shamt;
           }
           break;
         }
-        case 6: {
+        case 6:
+        {
           // RV32I: OR
           rddata[t].i = rsdata[t][0].i | rsdata[t][1].i;
           break;
         }
-        case 7: {
+        case 7:
+        {
           // RV32I: AND
           rddata[t].i = rsdata[t][0].i & rsdata[t][1].i;
           break;
@@ -356,61 +436,75 @@ void Warp::execute(const Instr &instr, pipeline_trace_t *trace) {
           std::abort();
         }
       }
-    }    
+    }
     rd_write = true;
     break;
   }
-  case I_INST: {
-    trace->exe_type = ExeType::ALU;    
-    trace->alu.type = AluType::ARITH;    
+  case I_INST:
+  {
+    trace->exe_type = ExeType::ALU;
+    trace->alu.type = AluType::ARITH;
     trace->used_iregs.set(rsrc0);
-    for (uint32_t t = 0; t < num_threads; ++t) {
+    for (uint32_t t = 0; t < num_threads; ++t)
+    {
       if (!tmask_.test(t))
         continue;
-      switch (func3) {
-      case 0: {
+      switch (func3)
+      {
+      case 0:
+      {
         // RV32I: ADDI
         rddata[t].i = rsdata[t][0].i + immsrc;
         break;
       }
-      case 1: {
+      case 1:
+      {
         // RV64I: SLLI
         rddata[t].i = rsdata[t][0].i << immsrc;
         break;
       }
-      case 2: {
+      case 2:
+      {
         // RV32I: SLTI
         rddata[t].i = WordI(rsdata[t][0].i) < WordI(immsrc);
         break;
       }
-      case 3: {
+      case 3:
+      {
         // RV32I: SLTIU
         rddata[t].i = rsdata[t][0].i < immsrc;
         break;
-      } 
-      case 4: {
+      }
+      case 4:
+      {
         // RV32I: XORI
         rddata[t].i = rsdata[t][0].i ^ immsrc;
         break;
       }
-      case 5: {
-        if (func7) {
+      case 5:
+      {
+        if (func7)
+        {
           // RV64I: SRAI
           Word result = WordI(rsdata[t][0].i) >> immsrc;
           rddata[t].i = result;
-        } else {
+        }
+        else
+        {
           // RV64I: SRLI
           Word result = Word(rsdata[t][0].i) >> immsrc;
           rddata[t].i = result;
         }
         break;
       }
-      case 6: {
+      case 6:
+      {
         // RV32I: ORI
         rddata[t].i = rsdata[t][0].i | immsrc;
         break;
       }
-      case 7: {
+      case 7:
+      {
         // RV32I: ANDI
         rddata[t].i = rsdata[t][0].i & immsrc;
         break;
@@ -420,104 +514,136 @@ void Warp::execute(const Instr &instr, pipeline_trace_t *trace) {
     rd_write = true;
     break;
   }
-  case R_INST_W: {
-    trace->exe_type = ExeType::ALU;    
+  case R_INST_W:
+  {
+    trace->exe_type = ExeType::ALU;
     trace->alu.type = AluType::ARITH;
     trace->used_iregs.set(rsrc0);
     trace->used_iregs.set(rsrc1);
-    for (uint32_t t = 0; t < num_threads; ++t) {
+    for (uint32_t t = 0; t < num_threads; ++t)
+    {
       if (!tmask_.test(t))
         continue;
-      if (func7 & 0x1){
-        switch (func3) {
-          case 0: {
-            // RV64M: MULW
-            int32_t product = (int32_t)rsdata[t][0].i * (int32_t)rsdata[t][1].i;
-            rddata[t].i = sext((uint64_t)product, 32);
-            trace->alu.type = AluType::IMUL;
-            break;
-          }
-          case 4: {
-            // RV64M: DIVW
-            int32_t dividen = (int32_t)rsdata[t][0].i;
-            int32_t divisor = (int32_t)rsdata[t][1].i;
-            int32_t quotient;
-            int32_t largest_negative = 0x80000000;
-            if (divisor == 0){
-              quotient = -1;
-            } else if (dividen == largest_negative && divisor == -1) {
-              quotient = dividen;
-            } else {
-              quotient = dividen / divisor;
-            }
-            rddata[t].i = sext((uint64_t)quotient, 32);
-            trace->alu.type = AluType::IDIV;
-            break;
-          }      
-          case 5: {
-            // RV64M: DIVUW
-            uint32_t dividen = (uint32_t)rsdata[t][0].i;
-            uint32_t divisor = (uint32_t)rsdata[t][1].i;
-            uint32_t quotient;
-            if (divisor == 0){
-              quotient = -1;
-            } else {
-              quotient = dividen / divisor;
-            }
-            rddata[t].i = sext((uint64_t)quotient, 32);
-            trace->alu.type = AluType::IDIV;
-            break;
-          } 
-          case 6: {
-            // RV64M: REMW
-            int32_t dividen = (uint32_t)rsdata[t][0].i;
-            int32_t divisor = (uint32_t)rsdata[t][1].i;
-            int32_t remainder;
-            int32_t largest_negative = 0x80000000;
-            if (divisor == 0){
-              remainder = dividen;
-            } else if (dividen == largest_negative && divisor == -1) {
-              remainder = 0;
-            } else {
-              remainder = dividen % divisor;
-            }
-            rddata[t].i = sext((uint64_t)remainder, 32);
-            trace->alu.type = AluType::IDIV;
-            break;
-          }  
-          case 7: {
-            // RV64M: REMUW
-            uint32_t dividen = (uint32_t)rsdata[t][0].i;
-            uint32_t divisor = (uint32_t)rsdata[t][1].i;
-            uint32_t remainder;
-            if (divisor == 0){
-              remainder = dividen;
-            } else {
-              remainder = dividen % divisor;
-            }
-            rddata[t].i = sext((uint64_t)remainder, 32);
-            trace->alu.type = AluType::IDIV;
-            break;
-          }  
-          default:
-            std::abort();
+      if (func7 & 0x1)
+      {
+        switch (func3)
+        {
+        case 0:
+        {
+          // RV64M: MULW
+          int32_t product = (int32_t)rsdata[t][0].i * (int32_t)rsdata[t][1].i;
+          rddata[t].i = sext((uint64_t)product, 32);
+          trace->alu.type = AluType::IMUL;
+          break;
         }
-      } else {
-        switch (func3) {
-        case 0: {
-          if (func7){
+        case 4:
+        {
+          // RV64M: DIVW
+          int32_t dividen = (int32_t)rsdata[t][0].i;
+          int32_t divisor = (int32_t)rsdata[t][1].i;
+          int32_t quotient;
+          int32_t largest_negative = 0x80000000;
+          if (divisor == 0)
+          {
+            quotient = -1;
+          }
+          else if (dividen == largest_negative && divisor == -1)
+          {
+            quotient = dividen;
+          }
+          else
+          {
+            quotient = dividen / divisor;
+          }
+          rddata[t].i = sext((uint64_t)quotient, 32);
+          trace->alu.type = AluType::IDIV;
+          break;
+        }
+        case 5:
+        {
+          // RV64M: DIVUW
+          uint32_t dividen = (uint32_t)rsdata[t][0].i;
+          uint32_t divisor = (uint32_t)rsdata[t][1].i;
+          uint32_t quotient;
+          if (divisor == 0)
+          {
+            quotient = -1;
+          }
+          else
+          {
+            quotient = dividen / divisor;
+          }
+          rddata[t].i = sext((uint64_t)quotient, 32);
+          trace->alu.type = AluType::IDIV;
+          break;
+        }
+        case 6:
+        {
+          // RV64M: REMW
+          int32_t dividen = (uint32_t)rsdata[t][0].i;
+          int32_t divisor = (uint32_t)rsdata[t][1].i;
+          int32_t remainder;
+          int32_t largest_negative = 0x80000000;
+          if (divisor == 0)
+          {
+            remainder = dividen;
+          }
+          else if (dividen == largest_negative && divisor == -1)
+          {
+            remainder = 0;
+          }
+          else
+          {
+            remainder = dividen % divisor;
+          }
+          rddata[t].i = sext((uint64_t)remainder, 32);
+          trace->alu.type = AluType::IDIV;
+          break;
+        }
+        case 7:
+        {
+          // RV64M: REMUW
+          uint32_t dividen = (uint32_t)rsdata[t][0].i;
+          uint32_t divisor = (uint32_t)rsdata[t][1].i;
+          uint32_t remainder;
+          if (divisor == 0)
+          {
+            remainder = dividen;
+          }
+          else
+          {
+            remainder = dividen % divisor;
+          }
+          rddata[t].i = sext((uint64_t)remainder, 32);
+          trace->alu.type = AluType::IDIV;
+          break;
+        }
+        default:
+          std::abort();
+        }
+      }
+      else
+      {
+        switch (func3)
+        {
+        case 0:
+        {
+          if (func7)
+          {
             // RV64I: SUBW
             uint32_t result = (uint32_t)rsdata[t][0].i - (uint32_t)rsdata[t][1].i;
             rddata[t].i = sext((uint64_t)result, 32);
           }
-          else{
+          else
+          {
             // RV64I: ADDW
             uint32_t result = (uint32_t)rsdata[t][0].i + (uint32_t)rsdata[t][1].i;
             rddata[t].i = sext((uint64_t)result, 32);
-          }    
+          }
           break;
         }
-        case 1: {
+        case 1:
+        {
           // RV64I: SLLW
           uint32_t shamt_mask = 0x1F;
           uint32_t shamt = rsdata[t][1].i & shamt_mask;
@@ -525,14 +651,18 @@ void Warp::execute(const Instr &instr, pipeline_trace_t *trace) {
           rddata[t].i = sext((uint64_t)result, 32);
           break;
         }
-        case 5: {
+        case 5:
+        {
           uint32_t shamt_mask = 0x1F;
           uint32_t shamt = rsdata[t][1].i & shamt_mask;
           uint32_t result;
-          if (func7) {
+          if (func7)
+          {
             // RV64I: SRAW
             result = (int32_t)rsdata[t][0].i >> shamt;
-          } else {
+          }
+          else
+          {
             // RV64I: SRLW
             result = (uint32_t)rsdata[t][0].i >> shamt;
           }
@@ -545,98 +675,122 @@ void Warp::execute(const Instr &instr, pipeline_trace_t *trace) {
       }
     }
     rd_write = true;
-    break; 
+    break;
   }
-  case I_INST_W: {
-    trace->exe_type = ExeType::ALU;    
-    trace->alu.type = AluType::ARITH;    
+  case I_INST_W:
+  {
+    trace->exe_type = ExeType::ALU;
+    trace->alu.type = AluType::ARITH;
     trace->used_iregs.set(rsrc0);
-    for (uint32_t t = 0; t < num_threads; ++t) {
+    for (uint32_t t = 0; t < num_threads; ++t)
+    {
       if (!tmask_.test(t))
         continue;
-      switch (func3) {
-        case 0: {
-          // RV64I: ADDIW
-          uint32_t result = (uint32_t)rsdata[t][0].i + (uint32_t)immsrc;
-          rddata[t].i = sext((uint64_t)result, 32);
-          break;
+      switch (func3)
+      {
+      case 0:
+      {
+        // RV64I: ADDIW
+        uint32_t result = (uint32_t)rsdata[t][0].i + (uint32_t)immsrc;
+        rddata[t].i = sext((uint64_t)result, 32);
+        break;
+      }
+      case 1:
+      {
+        // RV64I: SLLIW
+        uint32_t shamt_mask = 0x1F;
+        uint32_t shamt = immsrc & shamt_mask;
+        uint32_t result = rsdata[t][0].i << shamt;
+        rddata[t].i = sext((uint64_t)result, 32);
+        break;
+      }
+      case 5:
+      {
+        uint32_t shamt_mask = 0x1F;
+        uint32_t shamt = immsrc & shamt_mask;
+        uint32_t result;
+        if (func7)
+        {
+          // RV64I: SRAIW
+          result = (int32_t)rsdata[t][0].i >> shamt;
         }
-        case 1: {
-          // RV64I: SLLIW
-          uint32_t shamt_mask = 0x1F;
-          uint32_t shamt = immsrc & shamt_mask;
-          uint32_t result = rsdata[t][0].i << shamt;
-          rddata[t].i = sext((uint64_t)result, 32);
-          break;
-        }  
-        case 5: {
-          uint32_t shamt_mask = 0x1F;
-          uint32_t shamt = immsrc & shamt_mask;
-          uint32_t result;
-          if (func7) {
-            // RV64I: SRAIW
-            result = (int32_t)rsdata[t][0].i >> shamt;
-          } else {
-            // RV64I: SRLIW
-            result = (uint32_t)rsdata[t][0].i >> shamt;
-          }
-          rddata[t].i = sext((uint64_t)result, 32);
-          break;
+        else
+        {
+          // RV64I: SRLIW
+          result = (uint32_t)rsdata[t][0].i >> shamt;
         }
-        default:
-          std::abort();
+        rddata[t].i = sext((uint64_t)result, 32);
+        break;
+      }
+      default:
+        std::abort();
       }
     }
     rd_write = true;
     break;
   }
-  case B_INST: {   
-    trace->exe_type = ExeType::ALU;    
-    trace->alu.type = AluType::BRANCH;    
+  case B_INST:
+  {
+    trace->exe_type = ExeType::ALU;
+    trace->alu.type = AluType::BRANCH;
     trace->used_iregs.set(rsrc0);
     trace->used_iregs.set(rsrc1);
-    for (uint32_t t = 0; t < num_threads; ++t) {
+    for (uint32_t t = 0; t < num_threads; ++t)
+    {
       if (!tmask_.test(t))
         continue;
-      switch (func3) {
-      case 0: {
+      switch (func3)
+      {
+      case 0:
+      {
         // RV32I: BEQ
-        if (rsdata[t][0].i == rsdata[t][1].i) {
+        if (rsdata[t][0].i == rsdata[t][1].i)
+        {
           nextPC = uint32_t(PC_ + immsrc);
         }
         break;
       }
-      case 1: {
+      case 1:
+      {
         // RV32I: BNE
-        if (rsdata[t][0].i != rsdata[t][1].i) {
+        if (rsdata[t][0].i != rsdata[t][1].i)
+        {
           nextPC = uint32_t(PC_ + immsrc);
         }
         break;
       }
-      case 4: {
+      case 4:
+      {
         // RV32I: BLT
-        if (WordI(rsdata[t][0].i) < WordI(rsdata[t][1].i)) {
+        if (WordI(rsdata[t][0].i) < WordI(rsdata[t][1].i))
+        {
           nextPC = uint32_t(PC_ + immsrc);
         }
         break;
       }
-      case 5: {
+      case 5:
+      {
         // RV32I: BGE
-        if (WordI(rsdata[t][0].i) >= WordI(rsdata[t][1].i)) {
+        if (WordI(rsdata[t][0].i) >= WordI(rsdata[t][1].i))
+        {
           nextPC = uint32_t(PC_ + immsrc);
         }
         break;
       }
-      case 6: {
+      case 6:
+      {
         // RV32I: BLTU
-        if (Word(rsdata[t][0].i) < Word(rsdata[t][1].i)) {
+        if (Word(rsdata[t][0].i) < Word(rsdata[t][1].i))
+        {
           nextPC = uint32_t(PC_ + immsrc);
         }
         break;
       }
-      case 7: {
+      case 7:
+      {
         // RV32I: BGEU
-        if (Word(rsdata[t][0].i) >= Word(rsdata[t][1].i)) {
+        if (Word(rsdata[t][0].i) >= Word(rsdata[t][1].i))
+        {
           nextPC = uint32_t(PC_ + immsrc);
         }
         break;
@@ -650,14 +804,16 @@ void Warp::execute(const Instr &instr, pipeline_trace_t *trace) {
     break;
   }
   // RV32I: JAL
-  case JAL_INST: {
-    trace->exe_type = ExeType::ALU;    
+  case JAL_INST:
+  {
+    trace->exe_type = ExeType::ALU;
     trace->alu.type = AluType::BRANCH;
-    for (uint32_t t = 0; t < num_threads; ++t) {
+    for (uint32_t t = 0; t < num_threads; ++t)
+    {
       if (!tmask_.test(t))
         continue;
       rddata[t].i = nextPC;
-      nextPC = uint32_t(PC_ + immsrc);  
+      nextPC = uint32_t(PC_ + immsrc);
       trace->fetch_stall = true;
       break; // runonce
     }
@@ -665,11 +821,13 @@ void Warp::execute(const Instr &instr, pipeline_trace_t *trace) {
     break;
   }
   // RV32I: JALR
-  case JALR_INST: {
-    trace->exe_type = ExeType::ALU;    
+  case JALR_INST:
+  {
+    trace->exe_type = ExeType::ALU;
     trace->alu.type = AluType::BRANCH;
     trace->used_iregs.set(rsrc0);
-    for (uint32_t t = 0; t < num_threads; ++t) {
+    for (uint32_t t = 0; t < num_threads; ++t)
+    {
       if (!tmask_.test(t))
         continue;
       rddata[t].i = nextPC;
@@ -681,23 +839,25 @@ void Warp::execute(const Instr &instr, pipeline_trace_t *trace) {
     break;
   }
   case L_INST:
-  case FL: {
-    trace->exe_type = ExeType::LSU;    
+  case FL:
+  {
+    trace->exe_type = ExeType::LSU;
     trace->lsu.type = LsuType::LOAD;
     trace->used_iregs.set(rsrc0);
-    if ((opcode == L_INST )
-     || (opcode == FL && func3 == 2)
-     || (opcode == FL && func3 == 3)) {
+    if ((opcode == L_INST) || (opcode == FL && func3 == 2) || (opcode == FL && func3 == 3))
+    {
       uint32_t mem_bytes = 1 << (func3 & 0x3);
-      for (uint32_t t = 0; t < num_threads; ++t) {
+      for (uint32_t t = 0; t < num_threads; ++t)
+      {
         if (!tmask_.test(t))
           continue;
-        uint64_t mem_addr = rsdata[t][0].i + immsrc;         
+        uint64_t mem_addr = rsdata[t][0].i + immsrc;
         uint64_t mem_data = 0;
         core_->dcache_read(&mem_data, mem_addr, mem_bytes);
-        trace->mem_addrs.at(t).push_back({mem_addr, mem_bytes});        
+        trace->mem_addrs.at(t).push_back({mem_addr, mem_bytes});
         DP(4, "LOAD MEM: ADDRESS=0x" << std::hex << mem_addr << ", DATA=0x" << mem_data);
-        switch (func3) {
+        switch (func3)
+        {
         case 0:
           // RV32I: LB
           rddata[t].i = sext((Word)mem_data, 8);
@@ -707,10 +867,13 @@ void Warp::execute(const Instr &instr, pipeline_trace_t *trace) {
           rddata[t].i = sext((Word)mem_data, 16);
           break;
         case 2:
-          if (opcode == L_INST) {
+          if (opcode == L_INST)
+          {
             // RV32I: LW
             rddata[t].i = sext((Word)mem_data, 32);
-          } else {
+          }
+          else
+          {
             // RV32F: FLW
             rddata[t].f = nan_box((uint32_t)mem_data);
           }
@@ -723,24 +886,29 @@ void Warp::execute(const Instr &instr, pipeline_trace_t *trace) {
           rddata[t]._ = mem_data;
           break;
         default:
-          std::abort();      
+          std::abort();
         }
       }
-    } else { //arv: vector load
+    }
+    else
+    { // arv: vector load
       auto &vd = vreg_file_.at(rdest);
-      switch (instr.getVlsWidth()) {
-      case 6: {
-        for (uint32_t i = 0; i < vl_; i++) {
+      switch (instr.getVlsWidth())
+      {
+      case 6:
+      {
+        for (uint32_t i = 0; i < vl_; i++)
+        {
           Word mem_addr = ((rsdata[0][0].i) & 0xFFFFFFFC) + (i * vtype_.vsew / 8);
           Word mem_data = 0;
           core_->dcache_read(&mem_data, mem_addr, 4);
-          Word *result_ptr = (Word *)(vd.data() + i);
+          Word *result_ptr = (Word *)(vd.data() + (i * vtype_.vsew / 8));
           *result_ptr = mem_data;
           trace->mem_addrs.at(0).push_back({mem_addr, 4});
-          DP(4, "LOAD MEM: ADDRESS=0x" << std::hex << mem_addr << ", DATA=0x" << mem_data);        
+          DP(4, "LOAD MEM: ADDRESS=0x" << std::hex << mem_addr << ", DATA=0x" << mem_data);
         }
         break;
-      } 
+      }
       default:
         std::abort();
       }
@@ -748,46 +916,64 @@ void Warp::execute(const Instr &instr, pipeline_trace_t *trace) {
     rd_write = true;
     break;
   }
-  case S_INST:   
-  case FS: {
-    trace->exe_type = ExeType::LSU;    
+  case S_INST:
+  case FS:
+  {
+    trace->exe_type = ExeType::LSU;
     trace->lsu.type = LsuType::STORE;
     trace->used_iregs.set(rsrc0);
     trace->used_iregs.set(rsrc1);
-    if ((opcode == S_INST)
-     || (opcode == FS && func3 == 2)
-     || (opcode == FS && func3 == 3)) {
+    if ((opcode == S_INST) || (opcode == FS && func3 == 2) || (opcode == FS && func3 == 3))
+    {
       uint32_t mem_bytes = 1 << (func3 & 0x3);
-      uint64_t mask = ((uint64_t(1) << (8 * mem_bytes))-1);
-      for (uint32_t t = 0; t < num_threads; ++t) {
+      uint64_t mask = ((uint64_t(1) << (8 * mem_bytes)) - 1);
+      for (uint32_t t = 0; t < num_threads; ++t)
+      {
         if (!tmask_.test(t))
           continue;
         uint64_t mem_addr = rsdata[t][0].i + immsrc;
         uint64_t mem_data = rsdata[t][1]._;
-        if (mem_bytes < 8) {
+        if (mem_bytes < 8)
+        {
           mem_data &= mask;
         }
-        trace->mem_addrs.at(t).push_back({mem_addr, mem_bytes});        
+        trace->mem_addrs.at(t).push_back({mem_addr, mem_bytes});
         DP(4, "STORE MEM: ADDRESS=0x" << std::hex << mem_addr << ", DATA=0x" << mem_data);
-        switch (func3) {
+        switch (func3)
+        {
         case 0:
         case 1:
         case 2:
         case 3:
-          core_->dcache_write(&mem_data, mem_addr, mem_bytes);  
+          core_->dcache_write(&mem_data, mem_addr, mem_bytes);
           break;
         default:
           std::abort();
         }
       }
-    } else { //arv: vector store
-      for (uint32_t i = 0; i < vl_; i++) {
-        uint64_t mem_addr = rsdata[0][0].i + (i * vtype_.vsew / 8);        
-        switch (instr.getVlsWidth()) {
-        case 6: {
+    }
+    else
+    { // arv: vector store
+      for (uint32_t i = 0; i < vl_; i++)
+      {
+        uint64_t mem_addr = rsdata[0][0].i + (i * vtype_.vsew / 8);
+        switch (instr.getVlsWidth())
+        {
+        case 6:
+        {
           // store word and unit strided (not checking for unit stride)
-          auto& vr = vreg_file_.at(instr.getVs3());
-          uint32_t mem_data  = *(unsigned char *)(vr.data() + i); //arv: check - why unsigned char?
+          auto &vr = vreg_file_.at(instr.getVs3());
+          // uint32_t mem_data = *(unsigned char *)(vr.data() + i); // arv: unsigned char size = Byte size
+
+          // vk TODO: temp fix for 32 bit, will not work for larger since it may not fit in dcache, insert loop
+          uint32_t mem_data = 0;
+          int n = (vtype_.vsew / 8);
+
+          for (int j = 0; j < n; j++)
+          {
+            mem_data += (*(Byte *)(vr.data() + j + (i * vtype_.vsew / 8))) * (1 << (j * 8));
+          }
+
           core_->dcache_write(&mem_data, mem_addr, 4);
           trace->mem_addrs.at(0).push_back({mem_addr, 4});
           DP(4, "STORE MEM: ADDRESS=0x" << std::hex << mem_addr << ", DATA=0x" << mem_data);
@@ -795,27 +981,33 @@ void Warp::execute(const Instr &instr, pipeline_trace_t *trace) {
         }
         default:
           std::abort();
-        }          
+        }
       }
     }
     break;
   }
-  case SYS_INST: {
-    for (uint32_t t = 0; t < num_threads; ++t) {
+  case SYS_INST:
+  {
+    for (uint32_t t = 0; t < num_threads; ++t)
+    {
       if (!tmask_.test(t))
         continue;
       uint32_t csr_addr = immsrc;
       uint32_t csr_value;
-      if (func3 == 0) {
+      if (func3 == 0)
+      {
         trace->exe_type = ExeType::ALU;
         trace->alu.type = AluType::SYSCALL;
         trace->fetch_stall = true;
-        switch (csr_addr) {
-        case 0: { // RV32I: ECALL
+        switch (csr_addr)
+        {
+        case 0:
+        { // RV32I: ECALL
           core_->trigger_ecall();
           break;
         }
-        case 1: { // RV32I: EBREAK
+        case 1:
+        { // RV32I: EBREAK
           core_->trigger_ebreak();
           break;
         }
@@ -825,20 +1017,25 @@ void Warp::execute(const Instr &instr, pipeline_trace_t *trace) {
           break;
         default:
           std::abort();
-        }                
-      } else {
+        }
+      }
+      else
+      {
         trace->exe_type = ExeType::CSR;
         csr_value = core_->get_csr(csr_addr, t, id_);
-        switch (func3) {
-        case 1: {
+        switch (func3)
+        {
+        case 1:
+        {
           // RV32I: CSRRW
           rddata[t].i = csr_value;
-          core_->set_csr(csr_addr, rsdata[t][0].i, t, id_);      
+          core_->set_csr(csr_addr, rsdata[t][0].i, t, id_);
           trace->used_iregs.set(rsrc0);
           rd_write = true;
           break;
         }
-        case 2: {
+        case 2:
+        {
           // RV32I: CSRRS
           rddata[t].i = csr_value;
           core_->set_csr(csr_addr, csr_value | rsdata[t][0].i, t, id_);
@@ -846,7 +1043,8 @@ void Warp::execute(const Instr &instr, pipeline_trace_t *trace) {
           rd_write = true;
           break;
         }
-        case 3: {
+        case 3:
+        {
           // RV32I: CSRRC
           rddata[t].i = csr_value;
           core_->set_csr(csr_addr, csr_value & ~rsdata[t][0].i, t, id_);
@@ -854,21 +1052,24 @@ void Warp::execute(const Instr &instr, pipeline_trace_t *trace) {
           rd_write = true;
           break;
         }
-        case 5: {
+        case 5:
+        {
           // RV32I: CSRRWI
           rddata[t].i = csr_value;
-          core_->set_csr(csr_addr, rsrc0, t, id_);      
+          core_->set_csr(csr_addr, rsrc0, t, id_);
           rd_write = true;
           break;
         }
-        case 6: {
+        case 6:
+        {
           // RV32I: CSRRSI;
           rddata[t].i = csr_value;
           core_->set_csr(csr_addr, csr_value | rsrc0, t, id_);
           rd_write = true;
           break;
         }
-        case 7: {
+        case 7:
+        {
           // RV32I: CSRRCI
           rddata[t].i = csr_value;
           core_->set_csr(csr_addr, csr_value & ~rsrc0, t, id_);
@@ -879,25 +1080,31 @@ void Warp::execute(const Instr &instr, pipeline_trace_t *trace) {
           break;
         }
       }
-    } 
+    }
     break;
   }
   // RV32I: FENCE
-  case FENCE: {
-    trace->exe_type = ExeType::LSU;    
+  case FENCE:
+  {
+    trace->exe_type = ExeType::LSU;
     trace->lsu.type = LsuType::FENCE;
     break;
-  }   
-  case FCI: {       
-    trace->exe_type = ExeType::FPU;     
-    for (uint32_t t = 0; t < num_threads; ++t) {
+  }
+  case FCI:
+  {
+    trace->exe_type = ExeType::FPU;
+    for (uint32_t t = 0; t < num_threads; ++t)
+    {
       if (!tmask_.test(t))
-        continue; 
+        continue;
       uint32_t frm = get_fpu_rm(func3, core_, t, id_);
       uint32_t fflags = 0;
-      switch (func7) {
-      case 0x00: { // RV32F: FADD.S
-        if (checkBoxedArgs(&rddata[t].f, rsdata[t][0].f, rsdata[t][1].f, &fflags)) {
+      switch (func7)
+      {
+      case 0x00:
+      { // RV32F: FADD.S
+        if (checkBoxedArgs(&rddata[t].f, rsdata[t][0].f, rsdata[t][1].f, &fflags))
+        {
           rddata[t].f = nan_box(rv_fadd_s(rsdata[t][0].f, rsdata[t][1].f, frm, &fflags));
         }
         trace->fpu.type = FpuType::FMA;
@@ -905,15 +1112,18 @@ void Warp::execute(const Instr &instr, pipeline_trace_t *trace) {
         trace->used_fregs.set(rsrc1);
         break;
       }
-      case 0x01: { // RV32D: FADD.D
+      case 0x01:
+      { // RV32D: FADD.D
         rddata[t].f = rv_fadd_d(rsdata[t][0].f, rsdata[t][1].f, frm, &fflags);
         trace->fpu.type = FpuType::FMA;
         trace->used_fregs.set(rsrc0);
         trace->used_fregs.set(rsrc1);
         break;
       }
-      case 0x04: { // RV32F: FSUB.S
-        if (checkBoxedArgs(&rddata[t].f, rsdata[t][0].f, rsdata[t][1].f, &fflags)) {
+      case 0x04:
+      { // RV32F: FSUB.S
+        if (checkBoxedArgs(&rddata[t].f, rsdata[t][0].f, rsdata[t][1].f, &fflags))
+        {
           rddata[t].f = nan_box(rv_fsub_s(rsdata[t][0].f, rsdata[t][1].f, frm, &fflags));
         }
         trace->fpu.type = FpuType::FMA;
@@ -921,15 +1131,18 @@ void Warp::execute(const Instr &instr, pipeline_trace_t *trace) {
         trace->used_fregs.set(rsrc1);
         break;
       }
-      case 0x05: { // RV32D: FSUB.D
+      case 0x05:
+      { // RV32D: FSUB.D
         rddata[t].f = rv_fsub_d(rsdata[t][0].f, rsdata[t][1].f, frm, &fflags);
         trace->fpu.type = FpuType::FMA;
         trace->used_fregs.set(rsrc0);
         trace->used_fregs.set(rsrc1);
         break;
       }
-      case 0x08: { // RV32F: FMUL.S
-        if (checkBoxedArgs(&rddata[t].f, rsdata[t][0].f, rsdata[t][1].f, &fflags)) {
+      case 0x08:
+      { // RV32F: FMUL.S
+        if (checkBoxedArgs(&rddata[t].f, rsdata[t][0].f, rsdata[t][1].f, &fflags))
+        {
           rddata[t].f = nan_box(rv_fmul_s(rsdata[t][0].f, rsdata[t][1].f, frm, &fflags));
         }
         trace->fpu.type = FpuType::FMA;
@@ -937,15 +1150,18 @@ void Warp::execute(const Instr &instr, pipeline_trace_t *trace) {
         trace->used_fregs.set(rsrc1);
         break;
       }
-      case 0x09: { // RV32D: FMUL.D
+      case 0x09:
+      { // RV32D: FMUL.D
         rddata[t].f = rv_fmul_d(rsdata[t][0].f, rsdata[t][1].f, frm, &fflags);
         trace->fpu.type = FpuType::FMA;
         trace->used_fregs.set(rsrc0);
         trace->used_fregs.set(rsrc1);
         break;
       }
-      case 0x0c: { // RV32F: FDIV.S
-        if (checkBoxedArgs(&rddata[t].f, rsdata[t][0].f, rsdata[t][1].f, &fflags)) {
+      case 0x0c:
+      { // RV32F: FDIV.S
+        if (checkBoxedArgs(&rddata[t].f, rsdata[t][0].f, rsdata[t][1].f, &fflags))
+        {
           rddata[t].f = nan_box(rv_fdiv_s(rsdata[t][0].f, rsdata[t][1].f, frm, &fflags));
         }
         trace->fpu.type = FpuType::FDIV;
@@ -953,36 +1169,43 @@ void Warp::execute(const Instr &instr, pipeline_trace_t *trace) {
         trace->used_fregs.set(rsrc1);
         break;
       }
-      case 0x0d: { // RV32D: FDIV.D
+      case 0x0d:
+      { // RV32D: FDIV.D
         rddata[t].f = rv_fdiv_d(rsdata[t][0].f, rsdata[t][1].f, frm, &fflags);
         trace->fpu.type = FpuType::FDIV;
         trace->used_fregs.set(rsrc0);
         trace->used_fregs.set(rsrc1);
         break;
       }
-      case 0x2c: { // RV32F: FSQRT.S
-        if (checkBoxedArgs(&rddata[t].f, rsdata[t][0].f, &fflags)) {
+      case 0x2c:
+      { // RV32F: FSQRT.S
+        if (checkBoxedArgs(&rddata[t].f, rsdata[t][0].f, &fflags))
+        {
           rddata[t].f = nan_box(rv_fsqrt_s(rsdata[t][0].f, frm, &fflags));
         }
         trace->fpu.type = FpuType::FSQRT;
         trace->used_fregs.set(rsrc0);
         break;
       }
-      case 0x2d: { // RV32D: FSQRT.D
+      case 0x2d:
+      { // RV32D: FSQRT.D
         rddata[t].f = rv_fsqrt_d(rsdata[t][0].f, frm, &fflags);
         trace->fpu.type = FpuType::FSQRT;
         trace->used_fregs.set(rsrc0);
-        break;  
-      }       
-      case 0x10: {
-        if (checkBoxedArgs(&rddata[t].f, rsdata[t][0].f, rsdata[t][1].f, &fflags)) {
-          switch (func3) {            
+        break;
+      }
+      case 0x10:
+      {
+        if (checkBoxedArgs(&rddata[t].f, rsdata[t][0].f, rsdata[t][1].f, &fflags))
+        {
+          switch (func3)
+          {
           case 0: // RV32F: FSGNJ.S
             rddata[t].f = nan_box(rv_fsgnj_s(rsdata[t][0].f, rsdata[t][1].f));
-            break;          
+            break;
           case 1: // RV32F: FSGNJN.S
             rddata[t].f = nan_box(rv_fsgnjn_s(rsdata[t][0].f, rsdata[t][1].f));
-            break;          
+            break;
           case 2: // RV32F: FSGNJX.S
             rddata[t].f = nan_box(rv_fsgnjx_s(rsdata[t][0].f, rsdata[t][1].f));
             break;
@@ -993,14 +1216,16 @@ void Warp::execute(const Instr &instr, pipeline_trace_t *trace) {
         trace->used_fregs.set(rsrc1);
         break;
       }
-      case 0x11: {
-        switch (func3) {            
+      case 0x11:
+      {
+        switch (func3)
+        {
         case 0: // RV32D: FSGNJ.D
           rddata[t].f = rv_fsgnj_d(rsdata[t][0].f, rsdata[t][1].f);
-          break;          
+          break;
         case 1: // RV32D: FSGNJN.D
           rddata[t].f = rv_fsgnjn_d(rsdata[t][0].f, rsdata[t][1].f);
-          break;          
+          break;
         case 2: // RV32D: FSGNJX.D
           rddata[t].f = rv_fsgnjx_d(rsdata[t][0].f, rsdata[t][1].f);
           break;
@@ -1010,216 +1235,250 @@ void Warp::execute(const Instr &instr, pipeline_trace_t *trace) {
         trace->used_fregs.set(rsrc1);
         break;
       }
-      case 0x14: {   
-        if (checkBoxedArgs(&rddata[t].f, rsdata[t][0].f, rsdata[t][1].f, &fflags)) {         
-          if (func3) {
+      case 0x14:
+      {
+        if (checkBoxedArgs(&rddata[t].f, rsdata[t][0].f, rsdata[t][1].f, &fflags))
+        {
+          if (func3)
+          {
             // RV32F: FMAX.S
             rddata[t].f = nan_box(rv_fmax_s(rsdata[t][0].f, rsdata[t][1].f, &fflags));
-          } else {
+          }
+          else
+          {
             // RV32F: FMIN.S
             rddata[t].f = nan_box(rv_fmin_s(rsdata[t][0].f, rsdata[t][1].f, &fflags));
           }
         }
         trace->fpu.type = FpuType::FNCP;
         trace->used_fregs.set(rsrc0);
-        trace->used_fregs.set(rsrc1);        
+        trace->used_fregs.set(rsrc1);
         break;
       }
-      case 0x15: {            
-        if (func3) {
+      case 0x15:
+      {
+        if (func3)
+        {
           // RV32D: FMAX.D
           rddata[t].f = rv_fmax_d(rsdata[t][0].f, rsdata[t][1].f, &fflags);
-        } else {
+        }
+        else
+        {
           // RV32D: FMIN.D
           rddata[t].f = rv_fmin_d(rsdata[t][0].f, rsdata[t][1].f, &fflags);
         }
         trace->fpu.type = FpuType::FNCP;
         trace->used_fregs.set(rsrc0);
-        trace->used_fregs.set(rsrc1);        
+        trace->used_fregs.set(rsrc1);
         break;
       }
-      case 0x20: {
+      case 0x20:
+      {
         // RV32D: FCVT.S.D
         rddata[t].f = nan_box(rv_dtof(rsdata[t][0].f));
         trace->fpu.type = FpuType::FNCP;
         trace->used_fregs.set(rsrc0);
-        trace->used_fregs.set(rsrc1);        
+        trace->used_fregs.set(rsrc1);
         break;
       }
-      case 0x21: {
+      case 0x21:
+      {
         // RV32D: FCVT.D.S
         rddata[t].f = rv_ftod(rsdata[t][0].f);
         trace->fpu.type = FpuType::FNCP;
         trace->used_fregs.set(rsrc0);
-        trace->used_fregs.set(rsrc1);        
+        trace->used_fregs.set(rsrc1);
         break;
       }
-      case 0x60: {
-        switch (rsrc1) {
-          case 0: 
-            // RV32F: FCVT.W.S
-            rddata[t].i = sext((uint64_t)rv_ftoi_s(rsdata[t][0].f, frm, &fflags), 32);
-            break;
-          case 1:
-            // RV32F: FCVT.WU.S
-            rddata[t].i = sext((uint64_t)rv_ftou_s(rsdata[t][0].f, frm, &fflags), 32);
-            break;
-          case 2:
-            // RV64F: FCVT.L.S
-            rddata[t].i = rv_ftol_s(rsdata[t][0].f, frm, &fflags);
-            break;
-          case 3:
-            // RV64F: FCVT.LU.S
-            rddata[t].i = rv_ftolu_s(rsdata[t][0].f, frm, &fflags);
-            break;
-        }
-      trace->fpu.type = FpuType::FCVT;
-      trace->used_fregs.set(rsrc0);
-      break;
-    }
-      case 0x61: {
-        switch (rsrc1) {
-          case 0: 
-            // RV32D: FCVT.W.D
-            rddata[t].i = sext((uint64_t)rv_ftoi_d(rsdata[t][0].f, frm, &fflags), 32);
-            break;
-          case 1:
-            // RV32D: FCVT.WU.D
-            rddata[t].i = sext((uint64_t)rv_ftou_d(rsdata[t][0].f, frm, &fflags), 32);
-            break;
-          case 2:
-            // RV64D: FCVT.L.D
-            rddata[t].i = rv_ftol_d(rsdata[t][0].f, frm, &fflags);
-            break;
-          case 3:
-            // RV64D: FCVT.LU.D
-            rddata[t].i = rv_ftolu_d(rsdata[t][0].f, frm, &fflags);
-            break;
+      case 0x60:
+      {
+        switch (rsrc1)
+        {
+        case 0:
+          // RV32F: FCVT.W.S
+          rddata[t].i = sext((uint64_t)rv_ftoi_s(rsdata[t][0].f, frm, &fflags), 32);
+          break;
+        case 1:
+          // RV32F: FCVT.WU.S
+          rddata[t].i = sext((uint64_t)rv_ftou_s(rsdata[t][0].f, frm, &fflags), 32);
+          break;
+        case 2:
+          // RV64F: FCVT.L.S
+          rddata[t].i = rv_ftol_s(rsdata[t][0].f, frm, &fflags);
+          break;
+        case 3:
+          // RV64F: FCVT.LU.S
+          rddata[t].i = rv_ftolu_s(rsdata[t][0].f, frm, &fflags);
+          break;
         }
         trace->fpu.type = FpuType::FCVT;
         trace->used_fregs.set(rsrc0);
         break;
       }
-      case 0x70: {     
-        if (func3) {
+      case 0x61:
+      {
+        switch (rsrc1)
+        {
+        case 0:
+          // RV32D: FCVT.W.D
+          rddata[t].i = sext((uint64_t)rv_ftoi_d(rsdata[t][0].f, frm, &fflags), 32);
+          break;
+        case 1:
+          // RV32D: FCVT.WU.D
+          rddata[t].i = sext((uint64_t)rv_ftou_d(rsdata[t][0].f, frm, &fflags), 32);
+          break;
+        case 2:
+          // RV64D: FCVT.L.D
+          rddata[t].i = rv_ftol_d(rsdata[t][0].f, frm, &fflags);
+          break;
+        case 3:
+          // RV64D: FCVT.LU.D
+          rddata[t].i = rv_ftolu_d(rsdata[t][0].f, frm, &fflags);
+          break;
+        }
+        trace->fpu.type = FpuType::FCVT;
+        trace->used_fregs.set(rsrc0);
+        break;
+      }
+      case 0x70:
+      {
+        if (func3)
+        {
           // RV32F: FCLASS.S
           rddata[t].i = rv_fclss_s(rsdata[t][0].f);
-        } else {          
+        }
+        else
+        {
           // RV32F: FMV.X.W
           uint32_t result = (uint32_t)rsdata[t][0].f;
           rddata[t].i = sext((uint64_t)result, 32);
-        }        
+        }
         trace->fpu.type = FpuType::FNCP;
         trace->used_fregs.set(rsrc0);
         break;
       }
-      case 0x71: {    
-        if (func3) {
+      case 0x71:
+      {
+        if (func3)
+        {
           // RV32D: FCLASS.D
           rddata[t].i = rv_fclss_d(rsdata[t][0].f);
-        } else {          
+        }
+        else
+        {
           // RV64D: FMV.X.D
           rddata[t].i = rsdata[t][0].f;
-        }        
+        }
         trace->fpu.type = FpuType::FNCP;
         trace->used_fregs.set(rsrc0);
         break;
       }
-      case 0x50: {      
-        if (checkBoxedCmpArgs(&rddata[t].i, rsdata[t][0].f, rsdata[t][1].f, &fflags)) {     
-          switch (func3) {              
+      case 0x50:
+      {
+        if (checkBoxedCmpArgs(&rddata[t].i, rsdata[t][0].f, rsdata[t][1].f, &fflags))
+        {
+          switch (func3)
+          {
           case 0:
             // RV32F: FLE.S
-            rddata[t].i = rv_fle_s(rsdata[t][0].f, rsdata[t][1].f, &fflags);    
-            break;              
+            rddata[t].i = rv_fle_s(rsdata[t][0].f, rsdata[t][1].f, &fflags);
+            break;
           case 1:
             // RV32F: FLT.S
             rddata[t].i = rv_flt_s(rsdata[t][0].f, rsdata[t][1].f, &fflags);
-            break;              
+            break;
           case 2:
             // RV32F: FEQ.S
             rddata[t].i = rv_feq_s(rsdata[t][0].f, rsdata[t][1].f, &fflags);
             break;
           }
-        } 
+        }
         trace->fpu.type = FpuType::FNCP;
         trace->used_fregs.set(rsrc0);
         trace->used_fregs.set(rsrc1);
-        break; 
+        break;
       }
-      case 0x51: {           
-        switch (func3) {              
+      case 0x51:
+      {
+        switch (func3)
+        {
         case 0:
           // RV32D: FLE.D
-          rddata[t].i = rv_fle_d(rsdata[t][0].f, rsdata[t][1].f, &fflags);    
-          break;              
+          rddata[t].i = rv_fle_d(rsdata[t][0].f, rsdata[t][1].f, &fflags);
+          break;
         case 1:
           // RV32D: FLT.D
           rddata[t].i = rv_flt_d(rsdata[t][0].f, rsdata[t][1].f, &fflags);
-          break;              
+          break;
         case 2:
           // RV32D: FEQ.D
           rddata[t].i = rv_feq_d(rsdata[t][0].f, rsdata[t][1].f, &fflags);
           break;
-        } 
+        }
         trace->fpu.type = FpuType::FNCP;
         trace->used_fregs.set(rsrc0);
         trace->used_fregs.set(rsrc1);
-        break;  
-      }      
-      case 0x68: {
-        switch (rsrc1) {
-          case 0: 
-            // RV32F: FCVT.S.W
-            rddata[t].f = nan_box(rv_itof_s(rsdata[t][0].i, frm, &fflags));
-            break;
-          case 1:
-            // RV32F: FCVT.S.WU
-            rddata[t].f = nan_box(rv_utof_s(rsdata[t][0].i, frm, &fflags));
-            break;
-          case 2:
-            // RV64F: FCVT.S.L
-            rddata[t].f = nan_box(rv_ltof_s(rsdata[t][0].i, frm, &fflags));
-            break;
-          case 3:
-            // RV64F: FCVT.S.LU
-            rddata[t].f = nan_box(rv_lutof_s(rsdata[t][0].i, frm, &fflags));
-            break;
+        break;
+      }
+      case 0x68:
+      {
+        switch (rsrc1)
+        {
+        case 0:
+          // RV32F: FCVT.S.W
+          rddata[t].f = nan_box(rv_itof_s(rsdata[t][0].i, frm, &fflags));
+          break;
+        case 1:
+          // RV32F: FCVT.S.WU
+          rddata[t].f = nan_box(rv_utof_s(rsdata[t][0].i, frm, &fflags));
+          break;
+        case 2:
+          // RV64F: FCVT.S.L
+          rddata[t].f = nan_box(rv_ltof_s(rsdata[t][0].i, frm, &fflags));
+          break;
+        case 3:
+          // RV64F: FCVT.S.LU
+          rddata[t].f = nan_box(rv_lutof_s(rsdata[t][0].i, frm, &fflags));
+          break;
         }
         trace->fpu.type = FpuType::FCVT;
         trace->used_iregs.set(rsrc0);
         break;
       }
-      case 0x69: {
-        switch (rsrc1) {
-          case 0: 
-            // RV32D: FCVT.D.W
-            rddata[t].f = rv_itof_d(rsdata[t][0].i, frm, &fflags);
-            break;
-          case 1:
-            // RV32D: FCVT.D.WU
-            rddata[t].f = rv_utof_d(rsdata[t][0].i, frm, &fflags);
-            break;
-          case 2:
-            // RV64D: FCVT.D.L
-            rddata[t].f = rv_ltof_d(rsdata[t][0].i, frm, &fflags);
-            break;
-          case 3:
-            // RV64D: FCVT.D.LU
-            rddata[t].f = rv_lutof_d(rsdata[t][0].i, frm, &fflags);
-            break;
+      case 0x69:
+      {
+        switch (rsrc1)
+        {
+        case 0:
+          // RV32D: FCVT.D.W
+          rddata[t].f = rv_itof_d(rsdata[t][0].i, frm, &fflags);
+          break;
+        case 1:
+          // RV32D: FCVT.D.WU
+          rddata[t].f = rv_utof_d(rsdata[t][0].i, frm, &fflags);
+          break;
+        case 2:
+          // RV64D: FCVT.D.L
+          rddata[t].f = rv_ltof_d(rsdata[t][0].i, frm, &fflags);
+          break;
+        case 3:
+          // RV64D: FCVT.D.LU
+          rddata[t].f = rv_lutof_d(rsdata[t][0].i, frm, &fflags);
+          break;
         }
         trace->fpu.type = FpuType::FCVT;
         trace->used_iregs.set(rsrc0);
         break;
       }
-      case 0x78: { // RV32F: FMV.W.X
+      case 0x78:
+      { // RV32F: FMV.W.X
         rddata[t].f = nan_box((uint32_t)rsdata[t][0].i);
         trace->fpu.type = FpuType::FNCP;
         trace->used_iregs.set(rsrc0);
         break;
       }
-      case 0x79: { // RV64D: FMV.D.X
+      case 0x79:
+      { // RV64D: FMV.D.X
         rddata[t].f = rsdata[t][0].i;
         trace->fpu.type = FpuType::FNCP;
         trace->used_iregs.set(rsrc0);
@@ -1231,20 +1490,23 @@ void Warp::execute(const Instr &instr, pipeline_trace_t *trace) {
     rd_write = true;
     break;
   }
-  case FMADD:      
-  case FMSUB:      
+  case FMADD:
+  case FMSUB:
   case FMNMADD:
-  case FMNMSUB: {
+  case FMNMSUB:
+  {
     trace->fpu.type = FpuType::FMA;
     trace->used_fregs.set(rsrc0);
     trace->used_fregs.set(rsrc1);
     trace->used_fregs.set(rsrc2);
-    for (uint32_t t = 0; t < num_threads; ++t) {
+    for (uint32_t t = 0; t < num_threads; ++t)
+    {
       if (!tmask_.test(t))
         continue;
       uint32_t frm = get_fpu_rm(func3, core_, t, id_);
       uint32_t fflags = 0;
-      switch (opcode) {
+      switch (opcode)
+      {
       case FMADD:
         if (func2)
           // RV32D: FMADD.D
@@ -1257,7 +1519,7 @@ void Warp::execute(const Instr &instr, pipeline_trace_t *trace) {
         if (func2)
           // RV32D: FMSUB.D
           rddata[t].f = rv_fmsub_d(rsdata[t][0].f, rsdata[t][1].f, rsdata[t][2].f, frm, &fflags);
-        else 
+        else
           // RV32F: FMSUB.S
           rddata[t].f = nan_box(rv_fmsub_s(rsdata[t][0].f, rsdata[t][1].f, rsdata[t][2].f, frm, &fflags));
         break;
@@ -1268,7 +1530,7 @@ void Warp::execute(const Instr &instr, pipeline_trace_t *trace) {
         else
           // RV32F: FNMADD.S
           rddata[t].f = nan_box(rv_fnmadd_s(rsdata[t][0].f, rsdata[t][1].f, rsdata[t][2].f, frm, &fflags));
-        break; 
+        break;
       case FMNMSUB:
         if (func2)
           // RV32D: FNMSUB.D
@@ -1279,52 +1541,65 @@ void Warp::execute(const Instr &instr, pipeline_trace_t *trace) {
         break;
       default:
         break;
-      }              
+      }
       update_fcrs(fflags, core_, t, id_);
     }
     rd_write = true;
     break;
   }
-  case GPGPU: {    
+  case GPGPU:
+  {
     uint32_t ts = 0;
-    for (uint32_t t = 0; t < num_threads; ++t) {
-      if (tmask_.test(t)) {
+    for (uint32_t t = 0; t < num_threads; ++t)
+    {
+      if (tmask_.test(t))
+      {
         ts = t;
         break;
       }
     }
-    switch (func3) {
-    case 0: {
-      // TMC   
-      trace->exe_type = ExeType::GPU;     
+    switch (func3)
+    {
+    case 0:
+    {
+      // TMC
+      trace->exe_type = ExeType::GPU;
       trace->gpu.type = GpuType::TMC;
       trace->used_iregs.set(rsrc0);
       trace->fetch_stall = true;
-      if (rsrc1) {
+      if (rsrc1)
+      {
         // predicate mode
         ThreadMask pred;
-        for (uint32_t t = 0; t < num_threads; ++t) {
+        for (uint32_t t = 0; t < num_threads; ++t)
+        {
           pred[t] = tmask_.test(t) ? (ireg_file_.at(t).at(rsrc0) != 0) : 0;
         }
-        if (pred.any()) {
+        if (pred.any())
+        {
           tmask_ &= pred;
         }
-      } else {
+      }
+      else
+      {
         tmask_.reset();
-        for (uint32_t t = 0; t < num_threads; ++t) {
+        for (uint32_t t = 0; t < num_threads; ++t)
+        {
           tmask_.set(t, rsdata.at(ts)[0].i & (1 << t));
         }
       }
       DPH(3, "*** New TMC: ");
       for (uint32_t i = 0; i < num_threads; ++i)
-        DPN(3, tmask_.test(num_threads-i-1));
+        DPN(3, tmask_.test(num_threads - i - 1));
       DPN(3, std::endl);
 
       active_ = tmask_.any();
       trace->gpu.active_warps.reset();
       trace->gpu.active_warps.set(id_, active_);
-    } break;
-    case 1: {
+    }
+    break;
+    case 1:
+    {
       // WSPAWN
       trace->exe_type = ExeType::GPU;
       trace->gpu.type = GpuType::WSPAWN;
@@ -1332,51 +1607,66 @@ void Warp::execute(const Instr &instr, pipeline_trace_t *trace) {
       trace->used_iregs.set(rsrc1);
       trace->fetch_stall = true;
       trace->gpu.active_warps = core_->wspawn(rsdata.at(ts)[0].i, rsdata.at(ts)[1].i);
-    } break;
-    case 2: {
-      // SPLIT    
+    }
+    break;
+    case 2:
+    {
+      // SPLIT
       trace->exe_type = ExeType::GPU;
       trace->gpu.type = GpuType::SPLIT;
       trace->used_iregs.set(rsrc0);
       trace->fetch_stall = true;
-      if (HasDivergentThreads(tmask_, ireg_file_, rsrc0)) {          
+      if (HasDivergentThreads(tmask_, ireg_file_, rsrc0))
+      {
         ThreadMask tmask;
-        for (uint32_t t = 0; t < num_threads; ++t) {
+        for (uint32_t t = 0; t < num_threads; ++t)
+        {
           tmask[t] = tmask_.test(t) && !ireg_file_.at(t).at(rsrc0);
         }
 
         DomStackEntry e(tmask, nextPC);
         dom_stack_.push(tmask_);
         dom_stack_.push(e);
-        for (uint32_t t = 0, n = e.tmask.size(); t < n; ++t) {
+        for (uint32_t t = 0, n = e.tmask.size(); t < n; ++t)
+        {
           tmask_.set(t, !e.tmask.test(t) && tmask_.test(t));
         }
         active_ = tmask_.any();
 
         DPH(3, "*** Split: New TM=");
-        for (uint32_t t = 0; t < num_threads; ++t) DPN(3, tmask_.test(num_threads-t-1));
+        for (uint32_t t = 0; t < num_threads; ++t)
+          DPN(3, tmask_.test(num_threads - t - 1));
         DPN(3, ", Pushed TM=");
-        for (uint32_t t = 0; t < num_threads; ++t) DPN(3, e.tmask.test(num_threads-t-1));
+        for (uint32_t t = 0; t < num_threads; ++t)
+          DPN(3, e.tmask.test(num_threads - t - 1));
         DPN(3, ", PC=0x" << std::hex << e.PC << "\n");
-      } else {
+      }
+      else
+      {
         DP(3, "*** Unanimous pred");
         DomStackEntry e(tmask_);
         e.unanimous = true;
         dom_stack_.push(e);
-      }        
-    } break;
-    case 3: {
+      }
+    }
+    break;
+    case 3:
+    {
       // JOIN
       trace->exe_type = ExeType::GPU;
-      trace->gpu.type = GpuType::JOIN;        
-      trace->fetch_stall = true;        
-      if (!dom_stack_.empty() && dom_stack_.top().unanimous) {
+      trace->gpu.type = GpuType::JOIN;
+      trace->fetch_stall = true;
+      if (!dom_stack_.empty() && dom_stack_.top().unanimous)
+      {
         DP(3, "*** Uninimous branch at join");
         tmask_ = dom_stack_.top().tmask;
         active_ = tmask_.any();
         dom_stack_.pop();
-      } else {
-        if (!dom_stack_.top().fallThrough) {
+      }
+      else
+      {
+        if (!dom_stack_.top().fallThrough)
+        {
           nextPC = dom_stack_.top().PC;
           DP(3, "*** Join: next PC: " << std::hex << nextPC << std::dec);
         }
@@ -1385,72 +1675,89 @@ void Warp::execute(const Instr &instr, pipeline_trace_t *trace) {
         active_ = tmask_.any();
 
         DPH(3, "*** Join: New TM=");
-        for (uint32_t t = 0; t < num_threads; ++t) DPN(3, tmask_.test(num_threads-t-1));
+        for (uint32_t t = 0; t < num_threads; ++t)
+          DPN(3, tmask_.test(num_threads - t - 1));
         DPN(3, "\n");
 
         dom_stack_.pop();
-      }        
-    } break;
-    case 4: {
+      }
+    }
+    break;
+    case 4:
+    {
       // BAR
-      trace->exe_type = ExeType::GPU; 
+      trace->exe_type = ExeType::GPU;
       trace->gpu.type = GpuType::BAR;
       trace->used_iregs.set(rsrc0);
       trace->used_iregs.set(rsrc1);
       trace->fetch_stall = true;
       trace->gpu.active_warps = core_->barrier(rsdata[ts][0].i, rsdata[ts][1].i, id_);
-    } break;
-    case 5: {
+    }
+    break;
+    case 5:
+    {
       // PREFETCH
-      trace->exe_type = ExeType::LSU; 
-      trace->lsu.type = LsuType::PREFETCH; 
+      trace->exe_type = ExeType::LSU;
+      trace->lsu.type = LsuType::PREFETCH;
       trace->used_iregs.set(rsrc0);
-      for (uint32_t t = 0; t < num_threads; ++t) {
+      for (uint32_t t = 0; t < num_threads; ++t)
+      {
         if (!tmask_.test(t))
           continue;
         auto mem_addr = rsdata[t][0].i;
         trace->mem_addrs.at(t).push_back({mem_addr, 4});
       }
-    } break;
+    }
+    break;
     default:
       std::abort();
     }
-  }  break;
-  case GPU: {    
-    switch (func3) {
-    case 0: { // TEX
-      trace->exe_type = ExeType::GPU; 
+  }
+  break;
+  case GPU:
+  {
+    switch (func3)
+    {
+    case 0:
+    { // TEX
+      trace->exe_type = ExeType::GPU;
       trace->gpu.type = GpuType::TEX;
       trace->used_iregs.set(rsrc0);
       trace->used_iregs.set(rsrc1);
       trace->used_iregs.set(rsrc2);
-      for (uint32_t t = 0; t < num_threads; ++t) {
+      for (uint32_t t = 0; t < num_threads; ++t)
+      {
         if (!tmask_.test(t))
-          continue;        
-        auto unit  = func2;
-        auto u     = rsdata[t][0].i;
-        auto v     = rsdata[t][1].i;
-        auto lod   = rsdata[t][2].i;
+          continue;
+        auto unit = func2;
+        auto u = rsdata[t][0].i;
+        auto v = rsdata[t][1].i;
+        auto lod = rsdata[t][2].i;
         auto color = core_->tex_read(unit, u, v, lod, &trace->mem_addrs.at(t));
         rddata[t].i = color;
       }
       rd_write = true;
-    } break;
-    case 1: 
-      switch (func2) {
-      case 0: { // CMOV
+    }
+    break;
+    case 1:
+      switch (func2)
+      {
+      case 0:
+      { // CMOV
         trace->exe_type = ExeType::ALU;
         trace->alu.type = AluType::CMOV;
         trace->used_iregs.set(rsrc0);
         trace->used_iregs.set(rsrc1);
         trace->used_iregs.set(rsrc2);
-        for (uint32_t t = 0; t < num_threads; ++t) {
+        for (uint32_t t = 0; t < num_threads; ++t)
+        {
           if (!tmask_.test(t))
-            continue;     
+            continue;
           rddata[t].i = rsdata[t][0].i ? rsdata[t][1].i : rsdata[t][2].i;
         }
         rd_write = true;
-      } break;
+      }
+      break;
       default:
         std::abort();
       }
@@ -1458,876 +1765,1158 @@ void Warp::execute(const Instr &instr, pipeline_trace_t *trace) {
     default:
       std::abort();
     }
-  } break;
-  case VSET: {
-    uint32_t VLEN = core_->arch().vsize() * 8;
+  }
+  break;
+  case VSET:
+  {
+    uint32_t VLEN = core_->arch().vsize() * 8; // vk: each vreg defined as a vector of bytes
     uint32_t VLMAX = (instr.getVlmul() * VLEN) / instr.getVsew();
-    switch (func3) {
-    case 0: // vector-vector
-      switch (func6) {
-      case 0: { //arv: add
-        auto& vr1 = vreg_file_.at(rsrc0);
-        auto& vr2 = vreg_file_.at(rsrc1);
-        auto& vd = vreg_file_.at(rdest);
-        auto& mask = vreg_file_.at(0);
-        if (vtype_.vsew == 8) {
-          for (uint32_t i = 0; i < vl_; i++) {
+    /* vk:
+       VSEW - https://github.com/riscv/riscv-v-spec/blob/master/v-spec.adoc#341-vector-selected-element-width-vsew20
+       LMUL - https://github.com/riscv/riscv-v-spec/blob/master/v-spec.adoc#342-vector-register-grouping-vlmul20
+       VLMAX = LMUL * (VLEN/VSEW)
+     */
+    switch (func3) // bits 14:12
+    {
+    case 0: // OPIVV vector-vector
+      switch (func6)
+      {
+      case 0:
+      { // arv: add
+        auto &vr1 = vreg_file_.at(rsrc0);
+        auto &vr2 = vreg_file_.at(rsrc1);
+        auto &vd = vreg_file_.at(rdest);
+        auto &mask = vreg_file_.at(0); // vk: v0 is mask reg
+        if (vtype_.vsew == 8)
+        {
+          for (uint32_t i = 0; i < vl_; i++)
+          {
             uint8_t emask = *(uint8_t *)(mask.data() + i);
             uint8_t value = emask & 0x1;
-            if (vmask || (!vmask && value)) {
-              uint8_t first  = *(uint8_t *)(vr1.data() + i);
+            if (vmask || (!vmask && value)) // vk: vmask == 1 (unmasked), else take mask value from v0
+            {
+              uint8_t first = *(uint8_t *)(vr1.data() + i);
               uint8_t second = *(uint8_t *)(vr2.data() + i);
               uint8_t result = first + second;
               DP(3, "Adding " << first << " + " << second << " = " << result);
               *(uint8_t *)(vd.data() + i) = result;
             }
           }
-        } else if (vtype_.vsew == 16) {
-          for (uint32_t i = 0; i < vl_; i++) {
+        }
+        else if (vtype_.vsew == 16)
+        {
+          for (uint32_t i = 0; i < vl_; i++)
+          {
             uint16_t emask = *(uint16_t *)(mask.data() + i);
             uint16_t value = emask & 0x1;
-            if (vmask || (!vmask && value)) {
-              uint16_t first  = *(uint16_t *)(vr1.data() + i);
+            if (vmask || (!vmask && value))
+            {
+              uint16_t first = *(uint16_t *)(vr1.data() + i);
               uint16_t second = *(uint16_t *)(vr2.data() + i);
               uint16_t result = first + second;
               DP(3, "Adding " << first << " + " << second << " = " << result);
-              *(uint16_t *)(vd.data() + i) = result;
+              *(uint16_t *)(vd.data() + i * 2) = result;
             }
           }
-        } else if (vtype_.vsew == 32) {
-          for (uint32_t i = 0; i < vl_; i++) {
+        }
+        else if (vtype_.vsew == 32)
+        {
+          for (uint32_t i = 0; i < vl_; i++)
+          {
             uint32_t emask = *(uint32_t *)(mask.data() + i);
             uint32_t value = emask & 0x1;
-            if (vmask || (!vmask && value)) {
-              uint32_t first  = *(uint32_t *)(vr1.data() + i);
-              uint32_t second = *(uint32_t *)(vr2.data() + i);
+            if (vmask || (!vmask && value))
+            {
+              uint32_t first = *(uint32_t *)(vr1.data() + i * 4);
+              uint32_t second = *(uint32_t *)(vr2.data() + i * 4);
               uint32_t result = first + second;
               DP(3, "Adding " << first << " + " << second << " = " << result);
-              *(uint32_t *)(vd.data() + i) = result;
+              *(uint32_t *)(vd.data() + i * 4) = result;
             }
           }
-        }                
-      } break;
-      case 24: {
+        }
+      }
+      break;
+      case 24:
+      {
         // vmseq
         auto &vr1 = vreg_file_.at(rsrc0);
         auto &vr2 = vreg_file_.at(rsrc1);
         auto &vd = vreg_file_.at(rdest);
-        if (vtype_.vsew == 8) {
-          for (uint32_t i = 0; i < vl_; i++) {
-            uint8_t first  = *(uint8_t *)(vr1.data() + i);
+        if (vtype_.vsew == 8)
+        {
+          for (uint32_t i = 0; i < vl_; i++)
+          {
+            uint8_t first = *(uint8_t *)(vr1.data() + i);
             uint8_t second = *(uint8_t *)(vr2.data() + i);
             uint8_t result = (first == second) ? 1 : 0;
             DP(3, "Comparing " << first << " + " << second << " = " << result);
             *(uint8_t *)(vd.data() + i) = result;
           }
-        } else if (vtype_.vsew == 16) {
-          for (uint32_t i = 0; i < vl_; i++) {
-            uint16_t first  = *(uint16_t *)(vr1.data() + i);
+        }
+        else if (vtype_.vsew == 16)
+        {
+          for (uint32_t i = 0; i < vl_; i++)
+          {
+            uint16_t first = *(uint16_t *)(vr1.data() + i);
             uint16_t second = *(uint16_t *)(vr2.data() + i);
             uint16_t result = (first == second) ? 1 : 0;
             DP(3, "Comparing " << first << " + " << second << " = " << result);
             *(uint16_t *)(vd.data() + i) = result;
           }
-        } else if (vtype_.vsew == 32) {
-          for (uint32_t i = 0; i < vl_; i++) {
-            uint32_t first  = *(uint32_t *)(vr1.data() + i);
+        }
+        else if (vtype_.vsew == 32)
+        {
+          for (uint32_t i = 0; i < vl_; i++)
+          {
+            uint32_t first = *(uint32_t *)(vr1.data() + i);
             uint32_t second = *(uint32_t *)(vr2.data() + i);
             uint32_t result = (first == second) ? 1 : 0;
             DP(3, "Comparing " << first << " + " << second << " = " << result);
             *(uint32_t *)(vd.data() + i) = result;
           }
         }
-      } break;
-      case 25: { 
+      }
+      break;
+      case 25:
+      {
         // vmsne
         auto &vr1 = vreg_file_.at(rsrc0);
         auto &vr2 = vreg_file_.at(rsrc1);
         auto &vd = vreg_file_.at(rdest);
-        if (vtype_.vsew == 8) {
-          for (uint32_t i = 0; i < vl_; i++) {
-            uint8_t first  = *(uint8_t *)(vr1.data() + i);
+        if (vtype_.vsew == 8)
+        {
+          for (uint32_t i = 0; i < vl_; i++)
+          {
+            uint8_t first = *(uint8_t *)(vr1.data() + i);
             uint8_t second = *(uint8_t *)(vr2.data() + i);
             uint8_t result = (first != second) ? 1 : 0;
             DP(3, "Comparing " << first << " + " << second << " = " << result);
             *(uint8_t *)(vd.data() + i) = result;
           }
-        } else if (vtype_.vsew == 16) {
-          for (uint32_t i = 0; i < vl_; i++) {
-            uint16_t first  = *(uint16_t *)(vr1.data() + i);
+        }
+        else if (vtype_.vsew == 16)
+        {
+          for (uint32_t i = 0; i < vl_; i++)
+          {
+            uint16_t first = *(uint16_t *)(vr1.data() + i);
             uint16_t second = *(uint16_t *)(vr2.data() + i);
             uint16_t result = (first != second) ? 1 : 0;
             DP(3, "Comparing " << first << " + " << second << " = " << result);
             *(uint16_t *)(vd.data() + i) = result;
           }
-        } else if (vtype_.vsew == 32) {
-          for (uint32_t i = 0; i < vl_; i++) {
-            uint32_t first  = *(uint32_t *)(vr1.data() + i);
+        }
+        else if (vtype_.vsew == 32)
+        {
+          for (uint32_t i = 0; i < vl_; i++)
+          {
+            uint32_t first = *(uint32_t *)(vr1.data() + i);
             uint32_t second = *(uint32_t *)(vr2.data() + i);
             uint32_t result = (first != second) ? 1 : 0;
             DP(3, "Comparing " << first << " + " << second << " = " << result);
             *(uint32_t *)(vd.data() + i) = result;
           }
         }
-      } break;
-      case 26: {
+      }
+      break;
+      case 26:
+      {
         // vmsltu
         auto &vr1 = vreg_file_.at(rsrc0);
         auto &vr2 = vreg_file_.at(rsrc1);
         auto &vd = vreg_file_.at(rdest);
-        if (vtype_.vsew == 8) {
-          for (uint32_t i = 0; i < vl_; i++) {
-            uint8_t first  = *(uint8_t *)(vr1.data() + i);
+        if (vtype_.vsew == 8)
+        {
+          for (uint32_t i = 0; i < vl_; i++)
+          {
+            uint8_t first = *(uint8_t *)(vr1.data() + i);
             uint8_t second = *(uint8_t *)(vr2.data() + i);
             uint8_t result = (first < second) ? 1 : 0;
             DP(3, "Comparing " << first << " + " << second << " = " << result);
             *(uint8_t *)(vd.data() + i) = result;
           }
-        } else if (vtype_.vsew == 16) {
-          for (uint32_t i = 0; i < vl_; i++) {
-            uint16_t first  = *(uint16_t *)(vr1.data() + i);
+        }
+        else if (vtype_.vsew == 16)
+        {
+          for (uint32_t i = 0; i < vl_; i++)
+          {
+            uint16_t first = *(uint16_t *)(vr1.data() + i);
             uint16_t second = *(uint16_t *)(vr2.data() + i);
             uint16_t result = (first < second) ? 1 : 0;
             DP(3, "Comparing " << first << " + " << second << " = " << result);
             *(uint16_t *)(vd.data() + i) = result;
           }
-        } else if (vtype_.vsew == 32) {
-          for (uint32_t i = 0; i < vl_; i++) {
-            uint32_t first  = *(uint32_t *)(vr1.data() + i);
+        }
+        else if (vtype_.vsew == 32)
+        {
+          for (uint32_t i = 0; i < vl_; i++)
+          {
+            uint32_t first = *(uint32_t *)(vr1.data() + i);
             uint32_t second = *(uint32_t *)(vr2.data() + i);
             uint32_t result = (first < second) ? 1 : 0;
             DP(3, "Comparing " << first << " + " << second << " = " << result);
             *(uint32_t *)(vd.data() + i) = result;
           }
         }
-      } break;
-      case 27: {
+      }
+      break;
+      case 27:
+      {
         // vmslt
         auto &vr1 = vreg_file_.at(rsrc0);
         auto &vr2 = vreg_file_.at(rsrc1);
         auto &vd = vreg_file_.at(rdest);
-        if (vtype_.vsew == 8) {
-          for (uint32_t i = 0; i < vl_; i++) {
-            int8_t first  = *(int8_t *)(vr1.data() + i);
+        if (vtype_.vsew == 8)
+        {
+          for (uint32_t i = 0; i < vl_; i++)
+          {
+            int8_t first = *(int8_t *)(vr1.data() + i);
             int8_t second = *(int8_t *)(vr2.data() + i);
             int8_t result = (first < second) ? 1 : 0;
             DP(3, "Comparing " << first << " + " << second << " = " << result);
             *(uint8_t *)(vd.data() + i) = result;
           }
-        } else if (vtype_.vsew == 16) {
-          for (uint32_t i = 0; i < vl_; i++) {
-            int16_t first  = *(int16_t *)(vr1.data() + i);
+        }
+        else if (vtype_.vsew == 16)
+        {
+          for (uint32_t i = 0; i < vl_; i++)
+          {
+            int16_t first = *(int16_t *)(vr1.data() + i);
             int16_t second = *(int16_t *)(vr2.data() + i);
             int16_t result = (first < second) ? 1 : 0;
             DP(3, "Comparing " << first << " + " << second << " = " << result);
             *(int16_t *)(vd.data() + i) = result;
           }
-        } else if (vtype_.vsew == 32) {
-          for (uint32_t i = 0; i < vl_; i++) {
-            int32_t first  = *(int32_t *)(vr1.data() + i);
+        }
+        else if (vtype_.vsew == 32)
+        {
+          for (uint32_t i = 0; i < vl_; i++)
+          {
+            int32_t first = *(int32_t *)(vr1.data() + i);
             int32_t second = *(int32_t *)(vr2.data() + i);
             int32_t result = (first < second) ? 1 : 0;
             DP(3, "Comparing " << first << " + " << second << " = " << result);
             *(int32_t *)(vd.data() + i) = result;
           }
         }
-      } break;
-      case 28: {
+      }
+      break;
+      case 28:
+      {
         // vmsleu
         auto &vr1 = vreg_file_.at(rsrc0);
         auto &vr2 = vreg_file_.at(rsrc1);
         auto &vd = vreg_file_.at(rdest);
-        if (vtype_.vsew == 8) {
-          for (uint32_t i = 0; i < vl_; i++) {
-            uint8_t first  = *(uint8_t *)(vr1.data() + i);
+        if (vtype_.vsew == 8)
+        {
+          for (uint32_t i = 0; i < vl_; i++)
+          {
+            uint8_t first = *(uint8_t *)(vr1.data() + i);
             uint8_t second = *(uint8_t *)(vr2.data() + i);
             uint8_t result = (first <= second) ? 1 : 0;
             DP(3, "Comparing " << first << " + " << second << " = " << result);
             *(uint8_t *)(vd.data() + i) = result;
           }
-        } else if (vtype_.vsew == 16) {
-          for (uint32_t i = 0; i < vl_; i++) {
-            uint16_t first  = *(uint16_t *)(vr1.data() + i);
+        }
+        else if (vtype_.vsew == 16)
+        {
+          for (uint32_t i = 0; i < vl_; i++)
+          {
+            uint16_t first = *(uint16_t *)(vr1.data() + i);
             uint16_t second = *(uint16_t *)(vr2.data() + i);
             uint16_t result = (first <= second) ? 1 : 0;
             DP(3, "Comparing " << first << " + " << second << " = " << result);
             *(uint16_t *)(vd.data() + i) = result;
           }
-        } else if (vtype_.vsew == 32) {
-          for (uint32_t i = 0; i < vl_; i++) {
-            uint32_t first  = *(uint32_t *)(vr1.data() + i);
+        }
+        else if (vtype_.vsew == 32)
+        {
+          for (uint32_t i = 0; i < vl_; i++)
+          {
+            uint32_t first = *(uint32_t *)(vr1.data() + i);
             uint32_t second = *(uint32_t *)(vr2.data() + i);
             uint32_t result = (first <= second) ? 1 : 0;
             DP(3, "Comparing " << first << " + " << second << " = " << result);
             *(uint32_t *)(vd.data() + i) = result;
           }
         }
-      } break;
-      case 29: {
+      }
+      break;
+      case 29:
+      {
         // vmsle
         auto &vr1 = vreg_file_.at(rsrc0);
         auto &vr2 = vreg_file_.at(rsrc1);
         auto &vd = vreg_file_.at(rdest);
-        if (vtype_.vsew == 8) {
-          for (uint32_t i = 0; i < vl_; i++) {
-            int8_t first  = *(int8_t *)(vr1.data() + i);
+        if (vtype_.vsew == 8)
+        {
+          for (uint32_t i = 0; i < vl_; i++)
+          {
+            int8_t first = *(int8_t *)(vr1.data() + i);
             int8_t second = *(int8_t *)(vr2.data() + i);
             int8_t result = (first <= second) ? 1 : 0;
             DP(3, "Comparing " << first << " + " << second << " = " << result);
             *(uint8_t *)(vd.data() + i) = result;
           }
-        } else if (vtype_.vsew == 16) {
-          for (uint32_t i = 0; i < vl_; i++) {
-            int16_t first  = *(int16_t *)(vr1.data() + i);
+        }
+        else if (vtype_.vsew == 16)
+        {
+          for (uint32_t i = 0; i < vl_; i++)
+          {
+            int16_t first = *(int16_t *)(vr1.data() + i);
             int16_t second = *(int16_t *)(vr2.data() + i);
             int16_t result = (first <= second) ? 1 : 0;
             DP(3, "Comparing " << first << " + " << second << " = " << result);
             *(int16_t *)(vd.data() + i) = result;
           }
-        } else if (vtype_.vsew == 32) {
-          for (uint32_t i = 0; i < vl_; i++) {
-            int32_t first  = *(int32_t *)(vr1.data() + i);
+        }
+        else if (vtype_.vsew == 32)
+        {
+          for (uint32_t i = 0; i < vl_; i++)
+          {
+            int32_t first = *(int32_t *)(vr1.data() + i);
             int32_t second = *(int32_t *)(vr2.data() + i);
             int32_t result = (first <= second) ? 1 : 0;
             DP(3, "Comparing " << first << " + " << second << " = " << result);
             *(int32_t *)(vd.data() + i) = result;
           }
         }
-      } break;
-      case 30: {
+      }
+      break;
+      case 30:
+      {
         // vmsgtu
         auto &vr1 = vreg_file_.at(rsrc0);
         auto &vr2 = vreg_file_.at(rsrc1);
         auto &vd = vreg_file_.at(rdest);
-        if (vtype_.vsew == 8) {
-          for (uint32_t i = 0; i < vl_; i++) {
-            uint8_t first  = *(uint8_t *)(vr1.data() + i);
+        if (vtype_.vsew == 8)
+        {
+          for (uint32_t i = 0; i < vl_; i++)
+          {
+            uint8_t first = *(uint8_t *)(vr1.data() + i);
             uint8_t second = *(uint8_t *)(vr2.data() + i);
             uint8_t result = (first > second) ? 1 : 0;
             DP(3, "Comparing " << first << " + " << second << " = " << result);
             *(uint8_t *)(vd.data() + i) = result;
           }
-        } else if (vtype_.vsew == 16) {
-          for (uint32_t i = 0; i < vl_; i++) {
-            uint16_t first  = *(uint16_t *)(vr1.data() + i);
+        }
+        else if (vtype_.vsew == 16)
+        {
+          for (uint32_t i = 0; i < vl_; i++)
+          {
+            uint16_t first = *(uint16_t *)(vr1.data() + i);
             uint16_t second = *(uint16_t *)(vr2.data() + i);
             uint16_t result = (first > second) ? 1 : 0;
             DP(3, "Comparing " << first << " + " << second << " = " << result);
             *(uint16_t *)(vd.data() + i) = result;
           }
-        } else if (vtype_.vsew == 32) {
-          for (uint32_t i = 0; i < vl_; i++) {
-            uint32_t first  = *(uint32_t *)(vr1.data() + i);
+        }
+        else if (vtype_.vsew == 32)
+        {
+          for (uint32_t i = 0; i < vl_; i++)
+          {
+            uint32_t first = *(uint32_t *)(vr1.data() + i);
             uint32_t second = *(uint32_t *)(vr2.data() + i);
             uint32_t result = (first > second) ? 1 : 0;
             DP(3, "Comparing " << first << " + " << second << " = " << result);
             *(uint32_t *)(vd.data() + i) = result;
           }
         }
-      } break;
-      case 31: {
+      }
+      break;
+      case 31:
+      {
         // vmsgt
         auto &vr1 = vreg_file_.at(rsrc0);
         auto &vr2 = vreg_file_.at(rsrc1);
         auto &vd = vreg_file_.at(rdest);
-        if (vtype_.vsew == 8) {
-          for (uint32_t i = 0; i < vl_; i++) {
-            int8_t first  = *(int8_t *)(vr1.data() + i);
+        if (vtype_.vsew == 8)
+        {
+          for (uint32_t i = 0; i < vl_; i++)
+          {
+            int8_t first = *(int8_t *)(vr1.data() + i);
             int8_t second = *(int8_t *)(vr2.data() + i);
             int8_t result = (first > second) ? 1 : 0;
             DP(3, "Comparing " << first << " + " << second << " = " << result);
             *(uint8_t *)(vd.data() + i) = result;
           }
-        } else if (vtype_.vsew == 16) {
-          for (uint32_t i = 0; i < vl_; i++) {
-            int16_t first  = *(int16_t *)(vr1.data() + i);
+        }
+        else if (vtype_.vsew == 16)
+        {
+          for (uint32_t i = 0; i < vl_; i++)
+          {
+            int16_t first = *(int16_t *)(vr1.data() + i);
             int16_t second = *(int16_t *)(vr2.data() + i);
             int16_t result = (first > second) ? 1 : 0;
             DP(3, "Comparing " << first << " + " << second << " = " << result);
             *(int16_t *)(vd.data() + i) = result;
           }
-        } else if (vtype_.vsew == 32) {
-          for (uint32_t i = 0; i < vl_; i++) {
-            int32_t first  = *(int32_t *)(vr1.data() + i);
+        }
+        else if (vtype_.vsew == 32)
+        {
+          for (uint32_t i = 0; i < vl_; i++)
+          {
+            int32_t first = *(int32_t *)(vr1.data() + i);
             int32_t second = *(int32_t *)(vr2.data() + i);
             int32_t result = (first > second) ? 1 : 0;
             DP(3, "Comparing " << first << " + " << second << " = " << result);
             *(int32_t *)(vd.data() + i) = result;
           }
         }
-      } break;
       }
       break;
-    case 2: {
-      switch (func6) {
-      case 24: { 
+      }
+      break;
+    case 2: // OPMVV vector-vector
+    {
+      switch (func6)
+      {
+      case 24:
+      {
         // vmandnot
         auto &vr1 = vreg_file_.at(rsrc0);
         auto &vr2 = vreg_file_.at(rsrc1);
         auto &vd = vreg_file_.at(rdest);
-        if (vtype_.vsew == 8) {
-          for (uint32_t i = 0; i < vl_; i++) {
-            uint8_t first  = *(uint8_t *)(vr1.data() + i);
+        if (vtype_.vsew == 8)
+        {
+          for (uint32_t i = 0; i < vl_; i++)
+          {
+            uint8_t first = *(uint8_t *)(vr1.data() + i);
             uint8_t second = *(uint8_t *)(vr2.data() + i);
-            uint8_t first_value  = (first & 0x1);
+            uint8_t first_value = (first & 0x1);
             uint8_t second_value = (second & 0x1);
             uint8_t result = (first_value & !second_value);
             DP(3, "Comparing " << first << " + " << second << " = " << result);
             *(uint8_t *)(vd.data() + i) = result;
-          }            
-          for (uint32_t i = vl_; i < VLMAX; i++) {
+          }
+          for (uint32_t i = vl_; i < VLMAX; i++)
+          {
             *(uint8_t *)(vd.data() + i) = 0;
           }
-        } else if (vtype_.vsew == 16) {
-          for (uint32_t i = 0; i < vl_; i++) {
-            uint16_t first  = *(uint16_t *)(vr1.data() + i);
+        }
+        else if (vtype_.vsew == 16)
+        {
+          for (uint32_t i = 0; i < vl_; i++)
+          {
+            uint16_t first = *(uint16_t *)(vr1.data() + i);
             uint16_t second = *(uint16_t *)(vr2.data() + i);
-            uint16_t first_value  = (first & 0x1);
+            uint16_t first_value = (first & 0x1);
             uint16_t second_value = (second & 0x1);
             uint16_t result = (first_value & !second_value);
             DP(3, "Comparing " << first << " + " << second << " = " << result);
             *(uint16_t *)(vd.data() + i) = result;
           }
-          for (uint32_t i = vl_; i < VLMAX; i++) {
+          for (uint32_t i = vl_; i < VLMAX; i++)
+          {
             *(uint16_t *)(vd.data() + i) = 0;
           }
-        } else if (vtype_.vsew == 32) {
-          for (uint32_t i = 0; i < vl_; i++) {
-            uint32_t first  = *(uint32_t *)(vr1.data() + i);
+        }
+        else if (vtype_.vsew == 32)
+        {
+          for (uint32_t i = 0; i < vl_; i++)
+          {
+            uint32_t first = *(uint32_t *)(vr1.data() + i);
             uint32_t second = *(uint32_t *)(vr2.data() + i);
-            uint32_t first_value  = (first & 0x1);
+            uint32_t first_value = (first & 0x1);
             uint32_t second_value = (second & 0x1);
             uint32_t result = (first_value & !second_value);
             DP(3, "Comparing " << first << " + " << second << " = " << result);
             *(uint32_t *)(vd.data() + i) = result;
           }
-          for (uint32_t i = vl_; i < VLMAX; i++) {
+          for (uint32_t i = vl_; i < VLMAX; i++)
+          {
             *(uint32_t *)(vd.data() + i) = 0;
           }
         }
-      } break;
-      case 25: {
+      }
+      break;
+      case 25:
+      {
         // vmand
         auto &vr1 = vreg_file_.at(rsrc0);
         auto &vr2 = vreg_file_.at(rsrc1);
         auto &vd = vreg_file_.at(rdest);
-        if (vtype_.vsew == 8) {
-          for (uint32_t i = 0; i < vl_; i++) {
-            uint8_t first  = *(uint8_t *)(vr1.data() + i);
+        if (vtype_.vsew == 8)
+        {
+          for (uint32_t i = 0; i < vl_; i++)
+          {
+            uint8_t first = *(uint8_t *)(vr1.data() + i);
             uint8_t second = *(uint8_t *)(vr2.data() + i);
-            uint8_t first_value  = (first & 0x1);
+            uint8_t first_value = (first & 0x1);
             uint8_t second_value = (second & 0x1);
             uint8_t result = (first_value & second_value);
             DP(3, "Comparing " << first << " + " << second << " = " << result);
             *(uint8_t *)(vd.data() + i) = result;
           }
-          for (uint32_t i = vl_; i < VLMAX; i++) {
+          for (uint32_t i = vl_; i < VLMAX; i++)
+          {
             *(uint8_t *)(vd.data() + i) = 0;
           }
-        } else if (vtype_.vsew == 16) {
-          for (uint32_t i = 0; i < vl_; i++) {
-            uint16_t first  = *(uint16_t *)(vr1.data() + i);
+        }
+        else if (vtype_.vsew == 16)
+        {
+          for (uint32_t i = 0; i < vl_; i++)
+          {
+            uint16_t first = *(uint16_t *)(vr1.data() + i);
             uint16_t second = *(uint16_t *)(vr2.data() + i);
-            uint16_t first_value  = (first & 0x1);
+            uint16_t first_value = (first & 0x1);
             uint16_t second_value = (second & 0x1);
             uint16_t result = (first_value & second_value);
             DP(3, "Comparing " << first << " + " << second << " = " << result);
             *(uint16_t *)(vd.data() + i) = result;
           }
-          for (uint32_t i = vl_; i < VLMAX; i++) {
+          for (uint32_t i = vl_; i < VLMAX; i++)
+          {
             *(uint16_t *)(vd.data() + i) = 0;
           }
-        } else if (vtype_.vsew == 32) {
-          for (uint32_t i = 0; i < vl_; i++) {
-            uint32_t first  = *(uint32_t *)(vr1.data() + i);
+        }
+        else if (vtype_.vsew == 32)
+        {
+          for (uint32_t i = 0; i < vl_; i++)
+          {
+            uint32_t first = *(uint32_t *)(vr1.data() + i);
             uint32_t second = *(uint32_t *)(vr2.data() + i);
-            uint32_t first_value  = (first & 0x1);
+            uint32_t first_value = (first & 0x1);
             uint32_t second_value = (second & 0x1);
             uint32_t result = (first_value & second_value);
             DP(3, "Comparing " << first << " + " << second << " = " << result);
             *(uint32_t *)(vd.data() + i) = result;
           }
-          for (uint32_t i = vl_; i < VLMAX; i++) {
+          for (uint32_t i = vl_; i < VLMAX; i++)
+          {
             *(uint32_t *)(vd.data() + i) = 0;
           }
         }
-      } break;
-      case 26: {
+      }
+      break;
+      case 26:
+      {
         // vmor
         auto &vr1 = vreg_file_.at(rsrc0);
         auto &vr2 = vreg_file_.at(rsrc1);
         auto &vd = vreg_file_.at(rdest);
-        if (vtype_.vsew == 8) {
-          for (uint32_t i = 0; i < vl_; i++) {
-            uint8_t first  = *(uint8_t *)(vr1.data() + i);
+        if (vtype_.vsew == 8)
+        {
+          for (uint32_t i = 0; i < vl_; i++)
+          {
+            uint8_t first = *(uint8_t *)(vr1.data() + i);
             uint8_t second = *(uint8_t *)(vr2.data() + i);
-            uint8_t first_value  = (first & 0x1);
+            uint8_t first_value = (first & 0x1);
             uint8_t second_value = (second & 0x1);
             uint8_t result = (first_value | second_value);
             DP(3, "Comparing " << first << " + " << second << " = " << result);
             *(uint8_t *)(vd.data() + i) = result;
           }
-          for (uint32_t i = vl_; i < VLMAX; i++) {
+          for (uint32_t i = vl_; i < VLMAX; i++)
+          {
             *(uint8_t *)(vd.data() + i) = 0;
           }
-        } else if (vtype_.vsew == 16) {
-          for (uint32_t i = 0; i < vl_; i++) {
-            uint16_t first  = *(uint16_t *)(vr1.data() + i);
+        }
+        else if (vtype_.vsew == 16)
+        {
+          for (uint32_t i = 0; i < vl_; i++)
+          {
+            uint16_t first = *(uint16_t *)(vr1.data() + i);
             uint16_t second = *(uint16_t *)(vr2.data() + i);
-            uint16_t first_value  = (first & 0x1);
+            uint16_t first_value = (first & 0x1);
             uint16_t second_value = (second & 0x1);
             uint16_t result = (first_value | second_value);
             DP(3, "Comparing " << first << " + " << second << " = " << result);
             *(uint16_t *)(vd.data() + i) = result;
           }
-          for (uint32_t i = vl_; i < VLMAX; i++) {
+          for (uint32_t i = vl_; i < VLMAX; i++)
+          {
             *(uint16_t *)(vd.data() + i) = 0;
           }
-        } else if (vtype_.vsew == 32) {
-          for (uint32_t i = 0; i < vl_; i++) {
-            uint32_t first  = *(uint32_t *)(vr1.data() + i);
+        }
+        else if (vtype_.vsew == 32)
+        {
+          for (uint32_t i = 0; i < vl_; i++)
+          {
+            uint32_t first = *(uint32_t *)(vr1.data() + i);
             uint32_t second = *(uint32_t *)(vr2.data() + i);
-            uint32_t first_value  = (first & 0x1);
+            uint32_t first_value = (first & 0x1);
             uint32_t second_value = (second & 0x1);
             uint32_t result = (first_value | second_value);
             DP(3, "Comparing " << first << " + " << second << " = " << result);
             *(uint32_t *)(vd.data() + i) = result;
           }
-          for (uint32_t i = vl_; i < VLMAX; i++) {
+          for (uint32_t i = vl_; i < VLMAX; i++)
+          {
             *(uint32_t *)(vd.data() + i) = 0;
           }
         }
-      } break;
-      case 27: { 
+      }
+      break;
+      case 27:
+      {
         // vmxor
         auto &vr1 = vreg_file_.at(rsrc0);
         auto &vr2 = vreg_file_.at(rsrc1);
         auto &vd = vreg_file_.at(rdest);
-        if (vtype_.vsew == 8) {
-          for (uint32_t i = 0; i < vl_; i++) {
-            uint8_t first  = *(uint8_t *)(vr1.data() + i);
+        if (vtype_.vsew == 8)
+        {
+          for (uint32_t i = 0; i < vl_; i++)
+          {
+            uint8_t first = *(uint8_t *)(vr1.data() + i);
             uint8_t second = *(uint8_t *)(vr2.data() + i);
-            uint8_t first_value  = (first & 0x1);
+            uint8_t first_value = (first & 0x1);
             uint8_t second_value = (second & 0x1);
             uint8_t result = (first_value ^ second_value);
             DP(3, "Comparing " << first << " + " << second << " = " << result);
             *(uint8_t *)(vd.data() + i) = result;
           }
-          for (uint32_t i = vl_; i < VLMAX; i++) {
+          for (uint32_t i = vl_; i < VLMAX; i++)
+          {
             *(uint8_t *)(vd.data() + i) = 0;
           }
-        } else if (vtype_.vsew == 16) {
-          for (uint32_t i = 0; i < vl_; i++) {
-            uint16_t first  = *(uint16_t *)(vr1.data() + i);
+        }
+        else if (vtype_.vsew == 16)
+        {
+          for (uint32_t i = 0; i < vl_; i++)
+          {
+            uint16_t first = *(uint16_t *)(vr1.data() + i);
             uint16_t second = *(uint16_t *)(vr2.data() + i);
-            uint16_t first_value  = (first & 0x1);
+            uint16_t first_value = (first & 0x1);
             uint16_t second_value = (second & 0x1);
             uint16_t result = (first_value ^ second_value);
             DP(3, "Comparing " << first << " + " << second << " = " << result);
             *(uint16_t *)(vd.data() + i) = result;
           }
-          for (uint32_t i = vl_; i < VLMAX; i++) {
+          for (uint32_t i = vl_; i < VLMAX; i++)
+          {
             *(uint16_t *)(vd.data() + i) = 0;
           }
-        } else if (vtype_.vsew == 32) {
-          for (uint32_t i = 0; i < vl_; i++) {
-            uint32_t first  = *(uint32_t *)(vr1.data() + i);
+        }
+        else if (vtype_.vsew == 32)
+        {
+          for (uint32_t i = 0; i < vl_; i++)
+          {
+            uint32_t first = *(uint32_t *)(vr1.data() + i);
             uint32_t second = *(uint32_t *)(vr2.data() + i);
-            uint32_t first_value  = (first & 0x1);
+            uint32_t first_value = (first & 0x1);
             uint32_t second_value = (second & 0x1);
             uint32_t result = (first_value ^ second_value);
             DP(3, "Comparing " << first << " + " << second << " = " << result);
             *(uint32_t *)(vd.data() + i) = result;
           }
-          for (uint32_t i = vl_; i < VLMAX; i++) {
+          for (uint32_t i = vl_; i < VLMAX; i++)
+          {
             *(uint32_t *)(vd.data() + i) = 0;
           }
         }
-      } break;
-      case 28: {
+      }
+      break;
+      case 28:
+      {
         // vmornot
         auto &vr1 = vreg_file_.at(rsrc0);
         auto &vr2 = vreg_file_.at(rsrc1);
         auto &vd = vreg_file_.at(rdest);
-        if (vtype_.vsew == 8) {
-          for (uint32_t i = 0; i < vl_; i++) {
-            uint8_t first  = *(uint8_t *)(vr1.data() + i);
+        if (vtype_.vsew == 8)
+        {
+          for (uint32_t i = 0; i < vl_; i++)
+          {
+            uint8_t first = *(uint8_t *)(vr1.data() + i);
             uint8_t second = *(uint8_t *)(vr2.data() + i);
-            uint8_t first_value  = (first & 0x1);
+            uint8_t first_value = (first & 0x1);
             uint8_t second_value = (second & 0x1);
             uint8_t result = (first_value | !second_value);
             DP(3, "Comparing " << first << " + " << second << " = " << result);
             *(uint8_t *)(vd.data() + i) = result;
           }
-          for (uint32_t i = vl_; i < VLMAX; i++) {
+          for (uint32_t i = vl_; i < VLMAX; i++)
+          {
             *(uint8_t *)(vd.data() + i) = 0;
           }
-        } else if (vtype_.vsew == 16) {
-          for (uint32_t i = 0; i < vl_; i++) {
-            uint16_t first  = *(uint16_t *)(vr1.data() + i);
+        }
+        else if (vtype_.vsew == 16)
+        {
+          for (uint32_t i = 0; i < vl_; i++)
+          {
+            uint16_t first = *(uint16_t *)(vr1.data() + i);
             uint16_t second = *(uint16_t *)(vr2.data() + i);
-            uint16_t first_value  = (first & 0x1);
+            uint16_t first_value = (first & 0x1);
             uint16_t second_value = (second & 0x1);
             uint16_t result = (first_value | !second_value);
             DP(3, "Comparing " << first << " + " << second << " = " << result);
             *(uint16_t *)(vd.data() + i) = result;
           }
-          for (uint32_t i = vl_; i < VLMAX; i++) {
+          for (uint32_t i = vl_; i < VLMAX; i++)
+          {
             *(uint16_t *)(vd.data() + i) = 0;
           }
-        } else if (vtype_.vsew == 32) {
-          for (uint32_t i = 0; i < vl_; i++) {
-            uint32_t first  = *(uint32_t *)(vr1.data() + i);
+        }
+        else if (vtype_.vsew == 32)
+        {
+          for (uint32_t i = 0; i < vl_; i++)
+          {
+            uint32_t first = *(uint32_t *)(vr1.data() + i);
             uint32_t second = *(uint32_t *)(vr2.data() + i);
-            uint32_t first_value  = (first & 0x1);
+            uint32_t first_value = (first & 0x1);
             uint32_t second_value = (second & 0x1);
             uint32_t result = (first_value | !second_value);
             DP(3, "Comparing " << first << " + " << second << " = " << result);
             *(uint32_t *)(vd.data() + i) = result;
           }
-          for (uint32_t i = vl_; i < VLMAX; i++) {
+          for (uint32_t i = vl_; i < VLMAX; i++)
+          {
             *(uint32_t *)(vd.data() + i) = 0;
           }
         }
-      } break;
-      case 29: {
+      }
+      break;
+      case 29:
+      {
         // vmnand
         auto &vr1 = vreg_file_.at(rsrc0);
         auto &vr2 = vreg_file_.at(rsrc1);
         auto &vd = vreg_file_.at(rdest);
-        if (vtype_.vsew == 8) {
-          for (uint32_t i = 0; i < vl_; i++) {
-            uint8_t first  = *(uint8_t *)(vr1.data() + i);
+        if (vtype_.vsew == 8)
+        {
+          for (uint32_t i = 0; i < vl_; i++)
+          {
+            uint8_t first = *(uint8_t *)(vr1.data() + i);
             uint8_t second = *(uint8_t *)(vr2.data() + i);
-            uint8_t first_value  = (first & 0x1);
+            uint8_t first_value = (first & 0x1);
             uint8_t second_value = (second & 0x1);
             uint8_t result = !(first_value & second_value);
             DP(3, "Comparing " << first << " + " << second << " = " << result);
             *(uint8_t *)(vd.data() + i) = result;
           }
-          for (uint32_t i = vl_; i < VLMAX; i++) {
+          for (uint32_t i = vl_; i < VLMAX; i++)
+          {
             *(uint8_t *)(vd.data() + i) = 0;
           }
-        } else if (vtype_.vsew == 16) {
-          for (uint32_t i = 0; i < vl_; i++) {
-            uint16_t first  = *(uint16_t *)(vr1.data() + i);
+        }
+        else if (vtype_.vsew == 16)
+        {
+          for (uint32_t i = 0; i < vl_; i++)
+          {
+            uint16_t first = *(uint16_t *)(vr1.data() + i);
             uint16_t second = *(uint16_t *)(vr2.data() + i);
-            uint16_t first_value  = (first & 0x1);
+            uint16_t first_value = (first & 0x1);
             uint16_t second_value = (second & 0x1);
             uint16_t result = !(first_value & second_value);
             DP(3, "Comparing " << first << " + " << second << " = " << result);
             *(uint16_t *)(vd.data() + i) = result;
           }
-          for (uint32_t i = vl_; i < VLMAX; i++) {
+          for (uint32_t i = vl_; i < VLMAX; i++)
+          {
             *(uint16_t *)(vd.data() + i) = 0;
           }
-        } else if (vtype_.vsew == 32) {
-          for (uint32_t i = 0; i < vl_; i++) {
-            uint32_t first  = *(uint32_t *)(vr1.data() + i);
+        }
+        else if (vtype_.vsew == 32)
+        {
+          for (uint32_t i = 0; i < vl_; i++)
+          {
+            uint32_t first = *(uint32_t *)(vr1.data() + i);
             uint32_t second = *(uint32_t *)(vr2.data() + i);
-            uint32_t first_value  = (first & 0x1);
+            uint32_t first_value = (first & 0x1);
             uint32_t second_value = (second & 0x1);
             uint32_t result = !(first_value & second_value);
             DP(3, "Comparing " << first << " + " << second << " = " << result);
             *(uint32_t *)(vd.data() + i) = result;
           }
-          for (uint32_t i = vl_; i < VLMAX; i++) {
+          for (uint32_t i = vl_; i < VLMAX; i++)
+          {
             *(uint32_t *)(vd.data() + i) = 0;
           }
         }
-      } break;
-      case 30: {
+      }
+      break;
+      case 30:
+      {
         // vmnor
         auto &vr1 = vreg_file_.at(rsrc0);
         auto &vr2 = vreg_file_.at(rsrc1);
         auto &vd = vreg_file_.at(rdest);
-        if (vtype_.vsew == 8) {
-          for (uint32_t i = 0; i < vl_; i++) {
-            uint8_t first  = *(uint8_t *)(vr1.data() + i);
+        if (vtype_.vsew == 8)
+        {
+          for (uint32_t i = 0; i < vl_; i++)
+          {
+            uint8_t first = *(uint8_t *)(vr1.data() + i);
             uint8_t second = *(uint8_t *)(vr2.data() + i);
-            uint8_t first_value  = (first & 0x1);
+            uint8_t first_value = (first & 0x1);
             uint8_t second_value = (second & 0x1);
             uint8_t result = !(first_value | second_value);
             DP(3, "Comparing " << first << " + " << second << " = " << result);
             *(uint8_t *)(vd.data() + i) = result;
           }
-          for (uint32_t i = vl_; i < VLMAX; i++) {
+          for (uint32_t i = vl_; i < VLMAX; i++)
+          {
             *(uint8_t *)(vd.data() + i) = 0;
           }
-        } else if (vtype_.vsew == 16) {
-          for (uint32_t i = 0; i < vl_; i++) {
-            uint16_t first  = *(uint16_t *)(vr1.data() + i);
+        }
+        else if (vtype_.vsew == 16)
+        {
+          for (uint32_t i = 0; i < vl_; i++)
+          {
+            uint16_t first = *(uint16_t *)(vr1.data() + i);
             uint16_t second = *(uint16_t *)(vr2.data() + i);
-            uint16_t first_value  = (first & 0x1);
+            uint16_t first_value = (first & 0x1);
             uint16_t second_value = (second & 0x1);
             uint16_t result = !(first_value | second_value);
             DP(3, "Comparing " << first << " + " << second << " = " << result);
             *(uint16_t *)(vd.data() + i) = result;
           }
-          for (uint32_t i = vl_; i < VLMAX; i++) {
+          for (uint32_t i = vl_; i < VLMAX; i++)
+          {
             *(uint16_t *)(vd.data() + i) = 0;
           }
-        } else if (vtype_.vsew == 32) {
-          for (uint32_t i = 0; i < vl_; i++) {
-            uint32_t first  = *(uint32_t *)(vr1.data() + i);
+        }
+        else if (vtype_.vsew == 32)
+        {
+          for (uint32_t i = 0; i < vl_; i++)
+          {
+            uint32_t first = *(uint32_t *)(vr1.data() + i);
             uint32_t second = *(uint32_t *)(vr2.data() + i);
-            uint32_t first_value  = (first & 0x1);
+            uint32_t first_value = (first & 0x1);
             uint32_t second_value = (second & 0x1);
             uint32_t result = !(first_value | second_value);
             DP(3, "Comparing " << first << " + " << second << " = " << result);
             *(uint32_t *)(vd.data() + i) = result;
           }
-          for (uint32_t i = vl_; i < VLMAX; i++) {
+          for (uint32_t i = vl_; i < VLMAX; i++)
+          {
             *(uint32_t *)(vd.data() + i) = 0;
           }
         }
-      } break;
-      case 31: {
+      }
+      break;
+      case 31:
+      {
         // vmxnor
         auto &vr1 = vreg_file_.at(rsrc0);
         auto &vr2 = vreg_file_.at(rsrc1);
         auto &vd = vreg_file_.at(rdest);
-        if (vtype_.vsew == 8) {
-          for (uint32_t i = 0; i < vl_; i++) {
-            uint8_t first  = *(uint8_t *)(vr1.data() + i);
+        if (vtype_.vsew == 8)
+        {
+          for (uint32_t i = 0; i < vl_; i++)
+          {
+            uint8_t first = *(uint8_t *)(vr1.data() + i);
             uint8_t second = *(uint8_t *)(vr2.data() + i);
-            uint8_t first_value  = (first & 0x1);
+            uint8_t first_value = (first & 0x1);
             uint8_t second_value = (second & 0x1);
             uint8_t result = !(first_value ^ second_value);
             DP(3, "Comparing " << first << " + " << second << " = " << result);
             *(uint8_t *)(vd.data() + i) = result;
           }
-          for (uint32_t i = vl_; i < VLMAX; i++) {
+          for (uint32_t i = vl_; i < VLMAX; i++)
+          {
             *(uint8_t *)(vd.data() + i) = 0;
           }
-        } else if (vtype_.vsew == 16) {
-          for (uint32_t i = 0; i < vl_; i++) {
-            uint16_t first  = *(uint16_t *)(vr1.data() + i);
+        }
+        else if (vtype_.vsew == 16)
+        {
+          for (uint32_t i = 0; i < vl_; i++)
+          {
+            uint16_t first = *(uint16_t *)(vr1.data() + i);
             uint16_t second = *(uint16_t *)(vr2.data() + i);
-            uint16_t first_value  = (first & 0x1);
+            uint16_t first_value = (first & 0x1);
             uint16_t second_value = (second & 0x1);
             uint16_t result = !(first_value ^ second_value);
             DP(3, "Comparing " << first << " + " << second << " = " << result);
             *(uint16_t *)(vd.data() + i) = result;
           }
-          for (uint32_t i = vl_; i < VLMAX; i++) {
+          for (uint32_t i = vl_; i < VLMAX; i++)
+          {
             *(uint16_t *)(vd.data() + i) = 0;
           }
-        } else if (vtype_.vsew == 32) {
-          for (uint32_t i = 0; i < vl_; i++) {
-            uint32_t first  = *(uint32_t *)(vr1.data() + i);
+        }
+        else if (vtype_.vsew == 32)
+        {
+          for (uint32_t i = 0; i < vl_; i++)
+          {
+            uint32_t first = *(uint32_t *)(vr1.data() + i);
             uint32_t second = *(uint32_t *)(vr2.data() + i);
-            uint32_t first_value  = (first & 0x1);
+            uint32_t first_value = (first & 0x1);
             uint32_t second_value = (second & 0x1);
             uint32_t result = !(first_value ^ second_value);
             DP(3, "Comparing " << first << " + " << second << " = " << result);
             *(uint32_t *)(vd.data() + i) = result;
           }
-          for (uint32_t i = vl_; i < VLMAX; i++) {
+          for (uint32_t i = vl_; i < VLMAX; i++)
+          {
             *(uint32_t *)(vd.data() + i) = 0;
           }
         }
-      } break;
-      case 37: {
+      }
+      break;
+      case 37:
+      {
         // vmul
         auto &vr1 = vreg_file_.at(rsrc0);
         auto &vr2 = vreg_file_.at(rsrc1);
         auto &vd = vreg_file_.at(rdest);
-        if (vtype_.vsew == 8) {
-          for (uint32_t i = 0; i < vl_; i++) {
-            uint8_t first  = *(uint8_t *)(vr1.data() + i);
+        if (vtype_.vsew == 8)
+        {
+          for (uint32_t i = 0; i < vl_; i++)
+          {
+            uint8_t first = *(uint8_t *)(vr1.data() + i);
             uint8_t second = *(uint8_t *)(vr2.data() + i);
             uint8_t result = (first * second);
             DP(3, "Comparing " << first << " + " << second << " = " << result);
             *(uint8_t *)(vd.data() + i) = result;
           }
-          for (uint32_t i = vl_; i < VLMAX; i++) {
+          for (uint32_t i = vl_; i < VLMAX; i++)
+          {
             *(uint8_t *)(vd.data() + i) = 0;
           }
-        } else if (vtype_.vsew == 16) {
-          for (uint32_t i = 0; i < vl_; i++) {
-            uint16_t first  = *(uint16_t *)(vr1.data() + i);
+        }
+        else if (vtype_.vsew == 16)
+        {
+          for (uint32_t i = 0; i < vl_; i++)
+          {
+            uint16_t first = *(uint16_t *)(vr1.data() + i);
             uint16_t second = *(uint16_t *)(vr2.data() + i);
             uint16_t result = (first * second);
             DP(3, "Comparing " << first << " + " << second << " = " << result);
             *(uint16_t *)(vd.data() + i) = result;
           }
-          for (uint32_t i = vl_; i < VLMAX; i++) {
+          for (uint32_t i = vl_; i < VLMAX; i++)
+          {
             *(uint16_t *)(vd.data() + i) = 0;
           }
-        } else if (vtype_.vsew == 32) {
-          for (uint32_t i = 0; i < vl_; i++) {
-            uint32_t first  = *(uint32_t *)(vr1.data() + i);
+        }
+        else if (vtype_.vsew == 32)
+        {
+          for (uint32_t i = 0; i < vl_; i++)
+          {
+            uint32_t first = *(uint32_t *)(vr1.data() + i);
             uint32_t second = *(uint32_t *)(vr2.data() + i);
             uint32_t result = (first * second);
             DP(3, "Comparing " << first << " + " << second << " = " << result);
             *(uint32_t *)(vd.data() + i) = result;
           }
-          for (uint32_t i = vl_; i < VLMAX; i++) {
+          for (uint32_t i = vl_; i < VLMAX; i++)
+          {
             *(uint32_t *)(vd.data() + i) = 0;
           }
         }
-      } break;
-      case 45: {
+      }
+      break;
+      case 45:
+      {
         // vmacc
         auto &vr1 = vreg_file_.at(rsrc0);
         auto &vr2 = vreg_file_.at(rsrc1);
         auto &vd = vreg_file_.at(rdest);
-        if (vtype_.vsew == 8) {
-          for (uint32_t i = 0; i < vl_; i++) {
-            uint8_t first  = *(uint8_t *)(vr1.data() + i);
+        if (vtype_.vsew == 8)
+        {
+          for (uint32_t i = 0; i < vl_; i++)
+          {
+            uint8_t first = *(uint8_t *)(vr1.data() + i);
             uint8_t second = *(uint8_t *)(vr2.data() + i);
             uint8_t result = (first * second);
             DP(3, "Comparing " << first << " + " << second << " = " << result);
             *(uint8_t *)(vd.data() + i) += result;
           }
-          for (uint32_t i = vl_; i < VLMAX; i++) {
+          for (uint32_t i = vl_; i < VLMAX; i++)
+          {
             *(uint8_t *)(vd.data() + i) = 0;
           }
-        } else if (vtype_.vsew == 16) {
-          for (uint32_t i = 0; i < vl_; i++) {
-            uint16_t first  = *(uint16_t *)(vr1.data() + i);
+        }
+        else if (vtype_.vsew == 16)
+        {
+          for (uint32_t i = 0; i < vl_; i++)
+          {
+            uint16_t first = *(uint16_t *)(vr1.data() + i);
             uint16_t second = *(uint16_t *)(vr2.data() + i);
             uint16_t result = (first * second);
             DP(3, "Comparing " << first << " + " << second << " = " << result);
             *(uint16_t *)(vd.data() + i) += result;
           }
-          for (uint32_t i = vl_; i < VLMAX; i++) {
+          for (uint32_t i = vl_; i < VLMAX; i++)
+          {
             *(uint16_t *)(vd.data() + i) = 0;
           }
-        } else if (vtype_.vsew == 32) {
-          for (uint32_t i = 0; i < vl_; i++) {
-            uint32_t first  = *(uint32_t *)(vr1.data() + i);
+        }
+        else if (vtype_.vsew == 32)
+        {
+          for (uint32_t i = 0; i < vl_; i++)
+          {
+            uint32_t first = *(uint32_t *)(vr1.data() + i);
             uint32_t second = *(uint32_t *)(vr2.data() + i);
             uint32_t result = (first * second);
             DP(3, "Comparing " << first << " + " << second << " = " << result);
             *(uint32_t *)(vd.data() + i) += result;
           }
-          for (uint32_t i = vl_; i < VLMAX; i++) {
+          for (uint32_t i = vl_; i < VLMAX; i++)
+          {
             *(uint32_t *)(vd.data() + i) = 0;
           }
         }
-      } break;
       }
-    } break;
-    case 6: {
-      switch (func6) {
-      case 0: {
+      break;
+      }
+    }
+    break;
+    case 6: // OPMVX vector-scalar
+    {
+      switch (func6)
+      {
+      case 0:
+      {
         auto &vr2 = vreg_file_.at(rsrc1);
         auto &vd = vreg_file_.at(rdest);
-        if (vtype_.vsew == 8) {
-          for (uint32_t i = 0; i < vl_; i++) {
+        if (vtype_.vsew == 8)
+        {
+          for (uint32_t i = 0; i < vl_; i++)
+          {
             uint8_t second = *(uint8_t *)(vr2.data() + i);
             uint8_t result = (rsdata[i][0].i + second);
             DP(3, "Comparing " << rsdata[i][0].i << " + " << second << " = " << result);
             *(uint8_t *)(vd.data() + i) = result;
           }
-          for (uint32_t i = vl_; i < VLMAX; i++) {
+          for (uint32_t i = vl_; i < VLMAX; i++)
+          {
             *(uint8_t *)(vd.data() + i) = 0;
           }
-        } else if (vtype_.vsew == 16) {
-          for (uint32_t i = 0; i < vl_; i++) {
+        }
+        else if (vtype_.vsew == 16)
+        {
+          for (uint32_t i = 0; i < vl_; i++)
+          {
             uint16_t second = *(uint16_t *)(vr2.data() + i);
             uint16_t result = (rsdata[i][0].i + second);
             DP(3, "Comparing " << rsdata[i][0].i << " + " << second << " = " << result);
             *(uint16_t *)(vd.data() + i) = result;
           }
-          for (uint32_t i = vl_; i < VLMAX; i++) {
+          for (uint32_t i = vl_; i < VLMAX; i++)
+          {
             *(uint16_t *)(vd.data() + i) = 0;
           }
-        } else if (vtype_.vsew == 32) {
-          for (uint32_t i = 0; i < vl_; i++) {
+        }
+        else if (vtype_.vsew == 32)
+        {
+          for (uint32_t i = 0; i < vl_; i++)
+          {
             uint32_t second = *(uint32_t *)(vr2.data() + i);
             uint32_t result = (rsdata[i][0].i + second);
             DP(3, "Comparing " << rsdata[i][0].i << " + " << second << " = " << result);
             *(uint32_t *)(vd.data() + i) = result;
           }
-          for (uint32_t i = vl_; i < VLMAX; i++) {
+          for (uint32_t i = vl_; i < VLMAX; i++)
+          {
             *(uint32_t *)(vd.data() + i) = 0;
           }
         }
-      } break;
-      case 37: {
+      }
+      break;
+      case 37:
+      {
         // vmul.vx
         auto &vr2 = vreg_file_.at(rsrc1);
         auto &vd = vreg_file_.at(rdest);
-        if (vtype_.vsew == 8) {
-          for (uint32_t i = 0; i < vl_; i++) {
+        if (vtype_.vsew == 8)
+        {
+          for (uint32_t i = 0; i < vl_; i++)
+          {
             uint8_t second = *(uint8_t *)(vr2.data() + i);
             uint8_t result = (rsdata[i][0].i * second);
             DP(3, "Comparing " << rsdata[i][0].i << " + " << second << " = " << result);
             *(uint8_t *)(vd.data() + i) = result;
           }
-          for (uint32_t i = vl_; i < VLMAX; i++) {
+          for (uint32_t i = vl_; i < VLMAX; i++)
+          {
             *(uint8_t *)(vd.data() + i) = 0;
           }
-        } else if (vtype_.vsew == 16) {
-          for (uint32_t i = 0; i < vl_; i++) {
+        }
+        else if (vtype_.vsew == 16)
+        {
+          for (uint32_t i = 0; i < vl_; i++)
+          {
             uint16_t second = *(uint16_t *)(vr2.data() + i);
             uint16_t result = (rsdata[i][0].i * second);
             DP(3, "Comparing " << rsdata[i][0].i << " + " << second << " = " << result);
             *(uint16_t *)(vd.data() + i) = result;
           }
-          for (uint32_t i = vl_; i < VLMAX; i++) {
+          for (uint32_t i = vl_; i < VLMAX; i++)
+          {
             *(uint16_t *)(vd.data() + i) = 0;
           }
-        } else if (vtype_.vsew == 32) {
-          for (uint32_t i = 0; i < vl_; i++) {
+        }
+        else if (vtype_.vsew == 32)
+        {
+          for (uint32_t i = 0; i < vl_; i++)
+          {
             uint32_t second = *(uint32_t *)(vr2.data() + i);
             uint32_t result = (rsdata[i][0].i * second);
             DP(3, "Comparing " << rsdata[i][0].i << " + " << second << " = " << result);
             *(uint32_t *)(vd.data() + i) = result;
           }
-          for (uint32_t i = vl_; i < VLMAX; i++) {
+          for (uint32_t i = vl_; i < VLMAX; i++)
+          {
             *(uint32_t *)(vd.data() + i) = 0;
           }
         }
-      } break;
       }
-    } break;
-    case 7: {
-      vtype_.vill  = 0;
-      //vtype_.vediv = instr.getVediv();
-      vtype_.vsew  = instr.getVsew();
+      break;
+      }
+    }
+    break;
+    case 7: // OPCFG - config setting vector instructions
+    {
+      // vk: simx bug: vl_ not populated unless vsetvl/vsetvli called before using vector instructions - check
+      // vk: set defaults - handle exception?
+      vtype_.vill = 0;
+      // vtype_.vediv = instr.getVediv();
+      vtype_.vsew = instr.getVsew();
       vtype_.vlmul = instr.getVlmul();
 
-      DP(3, "lmul:" << vtype_.vlmul << " sew:" << vtype_.vsew  << /*" ediv: " << vtype_.vediv << */"rsrc_" << rsdata[0][0].i << "VLMAX" << VLMAX);
+      DP(3, "lmul:" << vtype_.vlmul << " sew:" << vtype_.vsew << /*" ediv: " << vtype_.vediv << */ "rsrc_" << rsdata[0][0].i << "VLMAX" << VLMAX);
 
       auto s0 = rsdata[0][0].i;
-      if (s0 <= VLMAX) {
+      // vk: s0 is the AVL value: https://github.com/riscv/riscv-v-spec/blob/master/v-spec.adoc#62-avl-encoding
+      // below logic description: https://github.com/riscv/riscv-v-spec/blob/master/v-spec.adoc#63-constraints-on-setting-vl
+      if (s0 <= VLMAX)
+      {
         vl_ = s0;
-      } else if (s0 < (2 * VLMAX)) { //arv: check - why this logic?
+      }
+      else if (s0 < (2 * VLMAX))
+      {
         vl_ = (uint32_t)ceil((s0 * 1.0) / 2.0);
-      } else if (s0 >= (2 * VLMAX)) { //arv: check - why this logic?
+      }
+      else if (s0 >= (2 * VLMAX))
+      {
         vl_ = VLMAX;
-      }        
+      }
       rddata[0].i = vl_;
       rd_write = true;
-    } break;
+    }
+    break;
     default:
       std::abort();
     }
-  } break;    
+  }
+  break;
   default:
     std::abort();
   }
 
-  if (rd_write) {
+  if (rd_write)
+  {
     trace->wb = true;
     DPH(2, "Dest Reg: ");
-    auto type = instr.getRDType();    
-    switch (type) {
-    case RegType::Integer:      
-      if (rdest) {    
-        DPN(2, type << std::dec << rdest << "={");    
-        for (uint32_t t = 0; t < num_threads; ++t) {
-          if (t) DPN(2, ", ");
-          if (!tmask_.test(t)) {
+    auto type = instr.getRDType();
+    switch (type)
+    {
+    case RegType::Integer:
+      if (rdest)
+      {
+        DPN(2, type << std::dec << rdest << "={");
+        for (uint32_t t = 0; t < num_threads; ++t)
+        {
+          if (t)
+            DPN(2, ", ");
+          if (!tmask_.test(t))
+          {
             DPN(2, "-");
-            continue;            
+            continue;
           }
           ireg_file_.at(t)[rdest] = rddata[t].i;
-          DPN(2, "0x" << std::hex << rddata[t].i);         
+          DPN(2, "0x" << std::hex << rddata[t].i);
         }
         DPN(2, "}" << std::endl);
         trace->used_iregs[rdest] = 1;
@@ -2335,19 +2924,22 @@ void Warp::execute(const Instr &instr, pipeline_trace_t *trace) {
       break;
     case RegType::Float:
       DPN(2, type << std::dec << rdest << "={");
-      for (uint32_t t = 0; t < num_threads; ++t) {
-        if (t) DPN(2, ", ");
-        if (!tmask_.test(t)) {
+      for (uint32_t t = 0; t < num_threads; ++t)
+      {
+        if (t)
+          DPN(2, ", ");
+        if (!tmask_.test(t))
+        {
           DPN(2, "-");
-          continue;            
+          continue;
         }
-        freg_file_.at(t)[rdest] = rddata[t].f;        
-        DPN(2, "0x" << std::hex << rddata[t].f);         
+        freg_file_.at(t)[rdest] = rddata[t].f;
+        DPN(2, "0x" << std::hex << rddata[t].f);
       }
       DPN(2, "}" << std::endl);
       trace->used_fregs[rdest] = 1;
       break;
-    case RegType::Vector: //arv: dest reg for vectors written earlier in program
+    case RegType::Vector: // arv: dest reg for vectors written earlier in program
       if ((opcode == VSET) && (func3 == 0x7))
       {
         ireg_file_.at(0)[rdest] = rddata[0].i;
@@ -2362,7 +2954,8 @@ void Warp::execute(const Instr &instr, pipeline_trace_t *trace) {
   }
 
   PC_ += core_->arch().wsize();
-  if (PC_ != nextPC) {
+  if (PC_ != nextPC)
+  {
     DP(3, "*** Next PC: " << std::hex << nextPC << std::dec);
     PC_ = nextPC;
   }

--- a/sim/simx/warp.cpp
+++ b/sim/simx/warp.cpp
@@ -11,75 +11,81 @@
 using namespace vortex;
 
 Warp::Warp(Core *core, uint32_t id)
-    : id_(id)
-    , core_(core)
-    , ireg_file_(core->arch().num_threads(), std::vector<Word>(core->arch().num_regs()))
-    , freg_file_(core->arch().num_threads(), std::vector<FWord>(core->arch().num_regs()))
-    , vreg_file_(core->arch().num_threads(), std::vector<Byte>(core->arch().vsize()))
+    : id_(id), core_(core), ireg_file_(core->arch().num_threads(), std::vector<Word>(core->arch().num_regs())), freg_file_(core->arch().num_threads(), std::vector<FWord>(core->arch().num_regs())), vreg_file_(core->arch().num_regs(), std::vector<Byte>(core->arch().vsize()))
 {
   this->clear();
 }
 
-void Warp::clear() {
+void Warp::clear()
+{
   active_ = false;
   PC_ = STARTUP_ADDR;
-  tmask_.reset();  
-  for (uint32_t i = 0, n = core_->arch().num_threads(); i < n; ++i) {
-    for (auto& reg : ireg_file_.at(i)) {
+  tmask_.reset();
+  for (uint32_t i = 0, n = core_->arch().num_threads(); i < n; ++i)
+  {
+    for (auto &reg : ireg_file_.at(i))
+    {
       reg = 0;
     }
-    for (auto& reg : freg_file_.at(i)) {
+    for (auto &reg : freg_file_.at(i))
+    {
       reg = 0;
     }
-    for (auto& reg : vreg_file_.at(i)) {
+    for (auto &reg : vreg_file_.at(i))
+    {
       reg = 0;
     }
   }
 }
 
-void Warp::eval(pipeline_trace_t *trace) {
+void Warp::eval(pipeline_trace_t *trace)
+{
   assert(tmask_.any());
 
   DPH(2, "Fetch: coreid=" << core_->id() << ", wid=" << id_ << ", tmask=");
   for (uint32_t i = 0, n = core_->arch().num_threads(); i < n; ++i)
-    DPN(2, tmask_.test(n-i-1));
+    DPN(2, tmask_.test(n - i - 1));
   DPN(2, ", PC=0x" << std::hex << PC_ << " (#" << std::dec << trace->uuid << ")" << std::endl);
 
-  /* Fetch and decode. */    
+  /* Fetch and decode. */
 
   uint32_t instr_code = 0;
   core_->icache_read(&instr_code, PC_, sizeof(uint32_t));
   auto instr = core_->decoder().decode(instr_code);
-  if (!instr) {
+  if (!instr)
+  {
     std::cout << std::hex << "Error: invalid instruction 0x" << instr_code << ", at PC=" << PC_ << std::endl;
     std::abort();
-  }  
+  }
 
   DP(2, "Instr 0x" << std::hex << instr_code << ": " << *instr);
 
   // Update trace
-  trace->cid   = core_->id();
-  trace->wid   = id_;
-  trace->PC    = PC_;
+  trace->cid = core_->id();
+  trace->wid = id_;
+  trace->PC = PC_;
   trace->tmask = tmask_;
   trace->rdest = instr->getRDest();
   trace->rdest_type = instr->getRDType();
-    
+
   // Execute
   this->execute(*instr, trace);
 
   DP(4, "Register state:");
-  for (uint32_t i = 0; i < core_->arch().num_regs(); ++i) {
+  for (uint32_t i = 0; i < core_->arch().num_regs(); ++i)
+  {
     DPN(4, "  %r" << std::setfill('0') << std::setw(2) << std::dec << i << ':');
     // Integer register file
-    for (uint32_t j = 0; j < core_->arch().num_threads(); ++j) {
-      DPN(4, ' ' << std::setfill('0') << std::setw(XLEN/4) << std::hex << ireg_file_.at(j).at(i) << std::setfill(' ') << ' ');
+    for (uint32_t j = 0; j < core_->arch().num_threads(); ++j)
+    {
+      DPN(4, ' ' << std::setfill('0') << std::setw(XLEN / 4) << std::hex << ireg_file_.at(j).at(i) << std::setfill(' ') << ' ');
     }
     DPN(4, '|');
     // Floating point register file
-    for (uint32_t j = 0; j < core_->arch().num_threads(); ++j) {
+    for (uint32_t j = 0; j < core_->arch().num_threads(); ++j)
+    {
       DPN(4, ' ' << std::setfill('0') << std::setw(16) << std::hex << freg_file_.at(j).at(i) << std::setfill(' ') << ' ');
     }
     DPN(4, std::endl);
-  }  
+  }
 }

--- a/sim/simx/warp.h
+++ b/sim/simx/warp.h
@@ -5,111 +5,120 @@
 #include <stack>
 #include "types.h"
 
-namespace vortex {
+namespace vortex
+{
 
-class Core;
-class Instr;
-class pipeline_trace_t;
-struct DomStackEntry {
-  DomStackEntry(const ThreadMask &tmask, Word PC) 
-    : tmask(tmask)
-    , PC(PC)
-    , fallThrough(false)
-    , unanimous(false) 
-  {}
+  class Core;
+  class Instr;
+  class pipeline_trace_t;
+  struct DomStackEntry
+  {
+    DomStackEntry(const ThreadMask &tmask, Word PC)
+        : tmask(tmask), PC(PC), fallThrough(false), unanimous(false)
+    {
+    }
 
-  DomStackEntry(const ThreadMask &tmask)
-      : tmask(tmask)
-      , PC(0)
-      , fallThrough(true)
-      , unanimous(false) 
-  {}
+    DomStackEntry(const ThreadMask &tmask)
+        : tmask(tmask), PC(0), fallThrough(true), unanimous(false)
+    {
+    }
 
-  ThreadMask tmask;
-  Word PC;
-  bool fallThrough;
-  bool unanimous;
-};
+    ThreadMask tmask;
+    Word PC;
+    bool fallThrough;
+    bool unanimous;
+  };
 
-struct vtype {
-  uint32_t vill;
-  uint32_t vediv;
-  uint32_t vsew;
-  uint32_t vlmul;
-};
+  struct vtype
+  {
+    uint32_t vill;
+    uint32_t vediv;
+    uint32_t vsew;
+    uint32_t vlmul;
+  };
 
-class Warp {
-public:
-  Warp(Core *core, uint32_t id);
+  class Warp
+  {
+  public:
+    Warp(Core *core, uint32_t id);
 
-  void clear();
-  
-  bool active() const {
-    return active_;
-  }
+    void clear();
 
-  void suspend() {
-    active_ = false;
-  }
+    bool active() const
+    {
+      return active_;
+    }
 
-  void activate() {
-    active_ = true;
-  }
+    void suspend()
+    {
+      active_ = false;
+    }
 
-  std::size_t getActiveThreads() const {
-    if (active_)
-      return tmask_.count();
-    return 0;
-  }
+    void activate()
+    {
+      active_ = true;
+    }
 
-  uint32_t id() const {
-    return id_;
-  }
+    std::size_t getActiveThreads() const
+    {
+      if (active_)
+        return tmask_.count();
+      return 0;
+    }
 
-  uint32_t getPC() const {
-    return PC_;
-  }
+    uint32_t id() const
+    {
+      return id_;
+    }
 
-  void setPC(uint32_t PC) {
-    PC_ = PC;
-  }
+    uint32_t getPC() const
+    {
+      return PC_;
+    }
 
-  void setTmask(size_t index, bool value) {
-    tmask_.set(index, value);
-    active_ = tmask_.any();
-  }
+    void setPC(uint32_t PC)
+    {
+      PC_ = PC;
+    }
 
-  uint32_t getTmask() const {
-    if (active_)
-      return tmask_.to_ulong();
-    return 0;
-  }
+    void setTmask(size_t index, bool value)
+    {
+      tmask_.set(index, value);
+      active_ = tmask_.any();
+    }
 
-  uint32_t getIRegValue(uint32_t reg) const {
-    return ireg_file_.at(0).at(reg);
-  }
+    uint32_t getTmask() const
+    {
+      if (active_)
+        return tmask_.to_ulong();
+      return 0;
+    }
 
-  void eval(pipeline_trace_t *);
+    uint32_t getIRegValue(uint32_t reg) const
+    {
+      return ireg_file_.at(0).at(reg);
+    }
 
-private:
+    void eval(pipeline_trace_t *);
 
-  void execute(const Instr &instr, pipeline_trace_t *trace);
-  
-  uint32_t id_;
-  Core *core_;
-  bool active_;
-  
-  Word PC_;
-  ThreadMask tmask_;  
-  
-  std::vector<std::vector<Word>> ireg_file_;
-  std::vector<std::vector<FWord>> freg_file_;
-  std::vector<std::vector<Byte>> vreg_file_;
-  std::stack<DomStackEntry> dom_stack_;
+  private:
+    void execute(const Instr &instr, pipeline_trace_t *trace);
 
-  struct vtype vtype_;
-  uint32_t vl_;
-};
+    uint32_t id_;
+    Core *core_;
+    bool active_;
+
+    Word PC_;
+    ThreadMask tmask_;
+
+    std::vector<std::vector<Word>> ireg_file_;
+    std::vector<std::vector<FWord>> freg_file_;
+    std::vector<std::vector<Byte>> vreg_file_; // num_threads x size of vector register
+    std::stack<DomStackEntry> dom_stack_;
+
+    struct vtype vtype_;
+    uint32_t vl_;
+  };
 
 }
 

--- a/tests/runtime/vecadd/main.cpp
+++ b/tests/runtime/vecadd/main.cpp
@@ -12,27 +12,30 @@
 
 int main()
 {
-    int n = 7; //SIZE
+    const int n = 4; // SIZE
 
-    int a[7] = {0,1,2,3,4,5,6};
-    int b[7] = {0,1,2,3,4,5,6};
-    int c[7] = {0,0,0,0,0,0,0};
+    // int a[7] = {0, 1, 2, 3, 4, 5, 200};
+    // int b[7] = {0, 1, 2, 3, 4, 5, 200};
+    // int c[7] = {0, 0, 0, 0, 0, 0, 0};
+
+    int a[n] = {1, 150, 200, 4};
+    int b[n] = {1, 152, 200, 3};
+    int c[n] = {0, 0, 0, 0};
 
     vx_vec_vvaddint32(n, (unsigned int)a, (unsigned int)b, (unsigned int)c);
 
     vx_printf("Start of program\n");
 
-    for(int i = 0; i < n; ++i) 
+    for (int i = 0; i < n; ++i)
     {
-        if(c[i] != (a[i]+b[i])) 
+        if (c[i] != (a[i] + b[i]))
         {
-           vx_printf("\n<vddint32> FAILED at <index: %d>! \n", i);
-           return 1;
+            vx_printf("\n<vddint32> FAILED at <index: %d> <value: %d>! \n", i, c[i]);
+            return 1;
         }
     }
 
     vx_printf("\nPASSED.......................... <vddint32> \n");
 
     return 0;
-
 }

--- a/tests/runtime/vecadd/main.cpp
+++ b/tests/runtime/vecadd/main.cpp
@@ -12,15 +12,15 @@
 
 int main()
 {
-    const int n = 4; // SIZE
+    const int n = 10; // SIZE
 
     // int a[7] = {0, 1, 2, 3, 4, 5, 200};
     // int b[7] = {0, 1, 2, 3, 4, 5, 200};
     // int c[7] = {0, 0, 0, 0, 0, 0, 0};
 
-    int a[n] = {1, 150, 200, 4};
-    int b[n] = {1, 152, 200, 3};
-    int c[n] = {0, 0, 0, 0};
+    int a[n] = {100, 150, 20, 0, 1, 150, 200, 150, 200, 4};
+    int b[n] = {20, 0, 1, 152, 200, 3, 1, 152, 200, 3};
+    int c[n] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
 
     vx_vec_vvaddint32(n, (unsigned int)a, (unsigned int)b, (unsigned int)c);
 


### PR DESCRIPTION
`vreg_file_` changes
- old: num_threads x vector_reg_size 
- new: 32 (num of regs) x vector_reg_size
- assuming single thread, 32 regs v0-v31 each of configurable size in bytes
- default implementation is 32 regs, each vreg having a width of 16bytes = 128 bits
- For vector add 32 (`vsew = 32`), each element of the vector takes up 4 elements in the` vreg_file_.at(rsrc/rdest)` vector
